### PR TITLE
Add Google Search Console meta to allow single property validation

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -20,6 +20,7 @@ export default function HTML(props) {
           src="//cdnjs.cloudflare.com/ajax/libs/jquery-scrollTo/2.1.2/jquery.scrollTo.min.js"
         />
         <script async src="https://www.googletagmanager.com/gtag/js?id=UA-56722061-8"></script>
+        <meta name="google-site-verification" content="VfXUU25hamqC0zHjgxvyVDPk8CqGiWjLSRFE8BZ1mmE" />
         <script type="text/javascript" src="/js/main.js" defer />
       </head>
       <body {...props.bodyAttributes}>


### PR DESCRIPTION
Just adding **Google Search Console** meta tag to allow single property validation. We already have domain validation, but to link **Google Analytics** with **Google Search** Console we also need to have a single URL property.