### PR TITLE
Remove DELETE/PUT convention

### DIFF
--- a/content/contribute/rest.md
+++ b/content/contribute/rest.md
@@ -4,40 +4,9 @@
 
 When writing new REST APIs, there are multiple ways to achieve the same feature.
 
+The basic can be found here: https://restfulapi.net/
 
-## Robustness principle
-
-Try to follow the [Robustness Principle](https://en.wikipedia.org/wiki/Robustness_principle):
-
-> Be conservative in what you do, be liberal in what you accept from others
-
-## REST API call = desired state, when possible
-
-Example:
-
-```ShellSession
-# Delete a user
-DELETE /user/12
-> 204
-# Delete the same user again
-DELETE /user/12
-> 204, not 404
-```
-
-Generalization: do not raise an error if the desired state of a resource is already attained.
-
-## PUT response = no body
-
-When receiving a PUT query, do not send the resource back in response.
-
-Pros:
-- less bandwidth
-- still available in edit event and query body
-- generally unused
-
-Cons:
-- body may be useful
-- resource may be deleted right after the PUT and won't be available by GET
+In additional of the following guidelines
 
 ## What is in GET /status?
 


### PR DESCRIPTION
We should just follow restapi.net guidelines.

In particular https://restfulapi.net/idempotent-rest-apis/ HTTP DELETE

That should return 404 when resource does not exists.