### PR TITLE
Fix error in develop when pageTitle props is not passed to Layout. Ca…

### DIFF
--- a/src/component/LayoutPlatform.js
+++ b/src/component/LayoutPlatform.js
@@ -11,10 +11,12 @@ import '../styles/platform/styles.scss';
 export default ({ children, section, className, pageTitle, breadcrumbs = [] }) => {
   const bodyAttributes = { class: section };
   const now = new Date();
+  const headTitle = [pageTitle, 'Wazo Platform'].filter(value => Boolean(value)).join(" - ");
+
   return (
     <div className="main">
       <Helmet bodyAttributes={bodyAttributes}>
-        <title>{pageTitle && `${pageTitle} - `}Wazo Platform</title>
+        <title>{headTitle}</title>
         <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
         <meta property="og:image" content="https://wazo-platform.org/images/og-image.jpg" />
         <link


### PR DESCRIPTION
Cannot see homepage in `develop` mode or others pages that don't pass `pageTitle` to `<Layout />` component. It's a regression since #136 have been merged.

## Steps to reproduce

- `yarn develop`
- Visit the homepage
- React Helmet error : ![Capture d’écran, le 2020-03-18 à 15 55 45](https://user-images.githubusercontent.com/1503758/77001820-ef28da00-6930-11ea-8b92-beebaa07d5f6.png)
 