### PR TITLE
zuul: increase timeout for website check

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -64,6 +64,7 @@
     description: Build and publish
     pre-run: zuul.d/pre.yaml
     run: zuul.d/run-test.yaml
+    timeout: 3600
 
 - project:
     check:


### PR DESCRIPTION
Why:

* 30 minutes is too short, Zuul job times out before finishing