### PR TITLE
Pull request for WAZO-1814-plugind-without-ssl

### DIFF
--- a/content/uc-doc/contributors/network.md
+++ b/content/uc-doc/contributors/network.md
@@ -50,4 +50,4 @@ Network Flow table (IN) :
 | wazo-phoned      | HTTPS        | TCP       | 9499 | 0.0.0.0   | IP filtering   | yes     |
 | wazo-calld       | HTTP         | TCP       | 9500 | 127.0.0.1 | yes            | yes     |
 | wazo-websocketd  | WSS          | TCP       | 9502 | 0.0.0.0   | yes            | yes     |
-| wazo-plugind     | HTTPS        | TCP       | 9503 | 0.0.0.0   | yes            | yes     |
+| wazo-plugind     | HTTP         | TCP       | 9503 | 127.0.0.1 | yes            | yes     |

--- a/content/uc-doc/upgrade/upgrade_notes.md
+++ b/content/uc-doc/upgrade/upgrade_notes.md
@@ -7,6 +7,12 @@ title: Upgrade notes
 - The wazo-confgend module that generates the SIP configuration for `chan_sip` has been removed. If
   you are still using `chan_sip` you will have to remove your custom configuration to use `pjsip`.
 
+- The TLS configuration has been deprecated on the following services. You should always use NGINX
+  to proxy communication with wazo-platform services. To follow this change, the listen address has
+  been changed to 127.0.0.1 by default.
+
+  - wazo-plugind
+
 ## 20.08 {#20-08}
 
 - The TLS configuration has been deprecated on the following services. You should always use NGINX


### PR DESCRIPTION
use plugind without ssl by default
