### PR TITLE
Pull request for WAZO-1820-provd-without-ssl

### DIFF
--- a/content/uc-doc/contributors/network.md
+++ b/content/uc-doc/contributors/network.md
@@ -33,7 +33,7 @@ Network Flow table (IN) :
 |                  | WAN          |           |      |           |                |         |
 | consul           | Consul HTTP  | TCP       | 8500 | 127.0.0.1 | both           | yes     |
 | consul           | Consul HTTPS | TCP       | 8501 | 127.0.0.1 | both           | yes     |
-| wazo-provd       | HTTPS        | TCP       | 8666 | 0.0.0.0   | yes            | yes     |
+| wazo-provd       | HTTP         | TCP       | 8666 | 127.0.0.1 | yes            | yes     |
 | wazo-provd       | HTTP         | TCP       | 8667 | 127.0.0.1 | no             | yes     |
 | wazo-confgend    | HTTP         | TCP       | 8669 | 127.0.0.1 | no             | yes     |
 | xivo-sysconfd    | HTTP         | TCP       | 8668 | 127.0.0.1 | no             | yes     |

--- a/content/uc-doc/contributors/network.md
+++ b/content/uc-doc/contributors/network.md
@@ -33,8 +33,8 @@ Network Flow table (IN) :
 |                  | WAN          |           |      |           |                |         |
 | consul           | Consul HTTP  | TCP       | 8500 | 127.0.0.1 | both           | yes     |
 | consul           | Consul HTTPS | TCP       | 8501 | 127.0.0.1 | both           | yes     |
-| wazo-provd       | HTTPS        | TCP       | 8666 | 127.0.0.1 | yes            | yes     |
-| wazo-provd       | HTTP         | TCP       | 8667 | 0.0.0.0   | no             | yes     |
+| wazo-provd       | HTTPS        | TCP       | 8666 | 0.0.0.0   | yes            | yes     |
+| wazo-provd       | HTTP         | TCP       | 8667 | 127.0.0.1 | no             | yes     |
 | wazo-confgend    | HTTP         | TCP       | 8669 | 127.0.0.1 | no             | yes     |
 | xivo-sysconfd    | HTTP         | TCP       | 8668 | 127.0.0.1 | no             | yes     |
 | wazo-auth        | HTTP         | TCP       | 9497 | 127.0.0.1 | both           | yes     |

--- a/content/uc-doc/upgrade/upgrade_notes.md
+++ b/content/uc-doc/upgrade/upgrade_notes.md
@@ -13,6 +13,7 @@ title: Upgrade notes
 
   - wazo-chatd
   - wazo-plugind
+  - wazo-provd
   - wazo-setupd
   - wazo-websocketd
 


### PR DESCRIPTION
use provd without ssl by default
fix provd networking info