### PR TITLE
[WAZO-1823] Fix sticky navigation lost when scrolling on Chrome 80+

### DIFF
--- a/src/component/documentation/api.js
+++ b/src/component/documentation/api.js
@@ -2,9 +2,28 @@ import React from 'react';
 import { RedocStandalone } from 'redoc';
 import { getModuleSpecUrl } from './helper';
 
-const defaultOptions = { pathInMiddlePanel: true, };
+const defaultOptions = { pathInMiddlePanel: true };
 
-export default ({ pageContext: { module } }) => <RedocStandalone
-  options={defaultOptions}
-  specUrl={getModuleSpecUrl(module)}
-/>;
+export default ({ pageContext: { module } }) => (
+  <>
+    {/* @patch Fix sticky menu on Chrome 80+ : https://github.com/Redocly/redoc/pull/1185 */}
+    <style
+      dangerouslySetInnerHTML={{
+        __html: `
+    @media (min-width: 801px) {
+      .menu-content {
+        position: fixed !important;
+        z-index: 10;
+      }
+
+      .api-content {
+        width: 100% !important;
+        padding-left: 260px;
+      }
+    }
+  `,
+      }}
+    />
+    <RedocStandalone options={defaultOptions} specUrl={getModuleSpecUrl(module)} />;
+  </>
+);


### PR DESCRIPTION
Hot patch for Redoc and sticky navigation on Google Chrome. Right now we cannot upgrade Redoc easily because of a dependency issue between Gatbsy and Redoc.

See : https://github.com/Redocly/redoc/pull/1185