### PR TITLE
[WAZO-1701] Fix call center 404 and improve pages

### DIFF
--- a/content/uc-doc/contact_center/agents.md
+++ b/content/uc-doc/contact_center/agents.md
@@ -4,20 +4,17 @@ title: Agents
 
 ## Introduction
 
-> *A call center agent is the person who handles incoming or outgoing
-> customer calls for a business. A call center agent might handle
-> account inquiries, customer complaints or support issues. Other names
-> for a call center agent include customer service representative (CSR),
-> telephone sales or service representative (TSR), attendant, associate,
-> operator, account executive or team member.*
+> _A call center agent is the person who handles incoming or outgoing customer calls for a business.
+> A call center agent might handle account inquiries, customer complaints or support issues. Other
+> names for a call center agent include customer service representative (CSR), telephone sales or
+> service representative (TSR), attendant, associate, operator, account executive or team member._
 >
 > \-- SearchCRM
 
-In this respect, agents in Wazo have no fixed line and can login from
-any registered device.
+In this respect, agents in Wazo have no fixed line and can login from any registered device.
 
 ## Getting Started
 
--   Create a user with a SIP line and a provisioned device.
--   Create agents.
--   Create a queue adding created agent as member of queue.
+- Create a user with a SIP line and a provisioned device.
+- Create agents.
+- Create a queue adding created agent as member of queue.

--- a/content/uc-doc/contact_center/agents.md
+++ b/content/uc-doc/contact_center/agents.md
@@ -2,9 +2,6 @@
 title: Agents
 ---
 
--   [Introduction](#introduction)
--   [Getting Started](#getting-started)
-
 Introduction
 ============
 

--- a/content/uc-doc/contact_center/agents.md
+++ b/content/uc-doc/contact_center/agents.md
@@ -2,8 +2,7 @@
 title: Agents
 ---
 
-Introduction
-============
+## Introduction
 
 > *A call center agent is the person who handles incoming or outgoing
 > customer calls for a business. A call center agent might handle
@@ -17,8 +16,7 @@ Introduction
 In this respect, agents in Wazo have no fixed line and can login from
 any registered device.
 
-Getting Started
-===============
+## Getting Started
 
 -   Create a user with a SIP line and a provisioned device.
 -   Create agents.

--- a/content/uc-doc/contact_center/index.md
+++ b/content/uc-doc/contact_center/index.md
@@ -2,7 +2,7 @@
 title: Contact Center
 ---
 
-- [Agents](/uc-doc/contact_center/agents/agents)
-- [Queues](/uc-doc/contact_center/queues/queues)
-- [Skill Based Routing](/uc-doc/contact_center/skillbasedrouting/skillbasedrouting)
-- [Reporting](/uc-doc/contact_center/reporting/reporting)
+- [Agents](/uc-doc/contact_center/agents)
+- [Queues](/uc-doc/contact_center/queues)
+- [Skill Based Routing](/uc-doc/contact_center/skillbasedrouting)
+- [Reporting](/uc-doc/contact_center/reporting)

--- a/content/uc-doc/contact_center/introduction.md
+++ b/content/uc-doc/contact_center/introduction.md
@@ -2,27 +2,18 @@
 title: Introduction
 ---
 
-In Wazo, the contact center is implemented to fulfill the following
-objectives :
+In Wazo, the contact center is implemented to fulfill the following objectives.
 
--   Call routing
+## Call routing
+Includes basic call distribution using call queues and skills-based routing
 
-    Includes basic call distribution using call queues and skills-based
-    routing
+## Agent and Supervisor workstation
+Provides the ability to execute contact center actions such as: agent login, agent logout and to receive real time statistics regarding contact center status
 
--   Agent and Supervisor workstation.
+## Statistics reporting
+Provides contact center management reporting on contact center activities
 
-    Provides the ability to execute contact center actions such as:
-    agent login, agent logout and to receive real time statistics
-    regarding contact center status
+## Advanced functionalities
 
--   Statistics reporting
-
-    Provides contact center management reporting on contact center
-    activities
-
--   Advanced functionalities
-
-    Call recording
-
--   Screen Pop-up
+- Call recording
+- Screen Pop-up

--- a/content/uc-doc/contact_center/introduction.md
+++ b/content/uc-doc/contact_center/introduction.md
@@ -5,12 +5,16 @@ title: Introduction
 In Wazo, the contact center is implemented to fulfill the following objectives.
 
 ## Call routing
+
 Includes basic call distribution using call queues and skills-based routing
 
 ## Agent and Supervisor workstation
-Provides the ability to execute contact center actions such as: agent login, agent logout and to receive real time statistics regarding contact center status
+
+Provides the ability to execute contact center actions such as: agent login, agent logout and to
+receive real time statistics regarding contact center status
 
 ## Statistics reporting
+
 Provides contact center management reporting on contact center activities
 
 ## Advanced functionalities

--- a/content/uc-doc/contact_center/queues.md
+++ b/content/uc-doc/contact_center/queues.md
@@ -32,8 +32,7 @@ enters the queue. A queue can use one of the following ring strategies:
 > distribution between multiple queues is nondeterministic and cannot be
 > configured.
 
-Timers
-======
+## Timers
 
 You may control how long a call will stay in a queue using different
 timers:
@@ -56,8 +55,7 @@ timers:
 
 ![](/images/uc-doc/contact_center/queues/queue_timers.jpg)
 
-Fallbacks
-=========
+## Fallbacks
 
 Calls can be diverted on no answer with `/queues/{queue_id}/fallbacks`
 endpoints:
@@ -71,8 +69,7 @@ endpoints:
     queued and no agents were available to answer
     (`options: leavewhenempty`).
 
-Diversions
-==========
+## Diversions
 
 Diversions can be used to redirect calls to another destination when a
 queue is very busy. Calls are redirected using one of the two threshold:
@@ -82,8 +79,7 @@ The diversion check is done only once per call, before the
 [preprocess subroutine](/uc-doc/api_sdk/subroutine) is
 executed and before the call enters the queue.
 
-`wait_time_threshold`
----------------------
+### `wait_time_threshold`
 
 When this scenario is used, the administrator can set a destination for
 calls to be sent to when the estimated waiting time is over the
@@ -92,7 +88,8 @@ threshold `wait_time_threshold`.
 Note that if a new call arrives when there are no waiting calls in the
 queue, the call will **always** be allowed to enter the queue.
 
-#!exclamation:
+#:exclamation:
+
 -   this *estimated* waiting time is computed from the **actual hold
     time** of all **answered** calls in the queue (since last asterisk
     restart) according to an [exponential smoothing
@@ -100,8 +97,7 @@ queue, the call will **always** be allowed to enter the queue.
 -   the estimated waiting time of a queue is updated only when a queue
     member answers a call.
 
-`wait_ratio_threshold` {#queue-diversion-waitratio}
-----------------------
+### `wait_ratio_threshold` {#queue-diversion-waitratio}
 
 When this scenario is used, the administrator can set a destination for
 calls to be sent to when the number of waiting calls per logged-in agent
@@ -145,8 +141,7 @@ example, in the following scenario:
 Even if `wait_ratio_time` (1) is greater than the maximum (0.5), the
 call will still be accepted since there are currently no waiting calls.
 
-Music on Hold {#moh}
-=============
+## Music on Hold {#moh}
 
 The `music_on_hold` of the queue will be played:
 

--- a/content/uc-doc/contact_center/queues.md
+++ b/content/uc-doc/contact_center/queues.md
@@ -2,118 +2,94 @@
 title: Queues
 ---
 
-Call queues are used to distribute calls to the agents subscribed to the
-queue. Queues are managed with the `/queues` endpoints
+Call queues are used to distribute calls to the agents subscribed to the queue. Queues are managed
+with the `/queues` endpoints
 
 A queue can be configured with the following options:
 
-A `options: strategy` defines how queue members are called when a call
-enters the queue. A queue can use one of the following ring strategies:
+A `options: strategy` defines how queue members are called when a call enters the queue. A queue can
+use one of the following ring strategies:
 
-> -   `linear`: For each call, in the same order, starting from the same
->     member
->     -   For agents: In login order
->     -   For static members: In definition order
-> -   `leastrecent`: call the member who least recently hung up a call
-> -   `fewestcalls`: call the member with the fewest completed calls
-> -   `rrmemory` (round robin with memory): call the "next" member
->     after the one who answered last
-> -   `random`: call a member at random
-> -   `wrandom` (weight random): same as random, but taking the member
->     penalty into account
-> -   `ringall`: call all members at the same time
+> - `linear`: For each call, in the same order, starting from the same member
+>   - For agents: In login order
+>   - For static members: In definition order
+> - `leastrecent`: call the member who least recently hung up a call
+> - `fewestcalls`: call the member with the fewest completed calls
+> - `rrmemory` (round robin with memory): call the "next" member after the one who answered last
+> - `random`: call a member at random
+> - `wrandom` (weight random): same as random, but taking the member penalty into account
+> - `ringall`: call all members at the same time
 >
-> #:warning: When editing a queue, you can't change the ring strategy to linear.
-> This is due to an asterisk limitation. Unfortunately, if you want to
-> change the ring strategy of a queue to linear, you'll have to delete
-> it first and then create a new queue with the right strategy.
+> #:warning: When editing a queue, you can't change the ring strategy to linear. This is due to an
+> asterisk limitation. Unfortunately, if you want to change the ring strategy of a queue to linear,
+> you'll have to delete it first and then create a new queue with the right strategy.
 
-> #:exclamation: When an agent is a member of many queues the order of call
-> distribution between multiple queues is nondeterministic and cannot be
-> configured.
+> #:exclamation: When an agent is a member of many queues the order of call distribution between
+> multiple queues is nondeterministic and cannot be configured.
 
 ## Timers
 
-You may control how long a call will stay in a queue using different
-timers:
+You may control how long a call will stay in a queue using different timers:
 
-> -   `options: timeout` (Member reachabillity time out): Maximum number
->     of seconds a call will ring on an agent's phone. If a call is not
->     answered within this time, the call will be forwarded to another
->     agent.
-> -   `retry_on_timeout` (Time before retrying a call to a member): Used
->     once a call has reached the "Member reachability time out". The
->     call will be put on hold for the number of seconds allowed before
->     being redirected to another agent.
-> -   `timeout` (Ringing time): The total time the call will stay in the
->     queue.
-> -   `options: timeoutpriority` (Timeout priority): Determines which
->     timeout to use before ending a call. When set to
->     "configuration", the call will use the "Member reachability
->     time out". When set to "dialplan", the call will use the
->     "Ringing time".
+> - `options: timeout` (Member reachabillity time out): Maximum number of seconds a call will ring
+>   on an agent's phone. If a call is not answered within this time, the call will be forwarded to
+>   another agent.
+> - `retry_on_timeout` (Time before retrying a call to a member): Used once a call has reached the
+>   "Member reachability time out". The call will be put on hold for the number of seconds allowed
+>   before being redirected to another agent.
+> - `timeout` (Ringing time): The total time the call will stay in the queue.
+> - `options: timeoutpriority` (Timeout priority): Determines which timeout to use before ending a
+>   call. When set to "configuration", the call will use the "Member reachability time out". When
+>   set to "dialplan", the call will use the "Ringing time".
 
 ![](/images/uc-doc/contact_center/queues/queue_timers.jpg)
 
 ## Fallbacks
 
-Calls can be diverted on no answer with `/queues/{queue_id}/fallbacks`
-endpoints:
+Calls can be diverted on no answer with `/queues/{queue_id}/fallbacks` endpoints:
 
--   `noanswer_destination`: The call reached the `timeout` and no agent
-    answered the call.
--   `congestion_destination`: The number of calls waiting has reached
-    the `options: maxlen`.
--   `fail_destination`: No agent was available to answer the call when
-    the call entered the queue (`options: joinempty`) or the call was
-    queued and no agents were available to answer
-    (`options: leavewhenempty`).
+- `noanswer_destination`: The call reached the `timeout` and no agent answered the call.
+- `congestion_destination`: The number of calls waiting has reached the `options: maxlen`.
+- `fail_destination`: No agent was available to answer the call when the call entered the queue
+  (`options: joinempty`) or the call was queued and no agents were available to answer
+  (`options: leavewhenempty`).
 
 ## Diversions
 
-Diversions can be used to redirect calls to another destination when a
-queue is very busy. Calls are redirected using one of the two threshold:
-`wait_ratio_threshold` and `ẁait_time_threshold`
+Diversions can be used to redirect calls to another destination when a queue is very busy. Calls are
+redirected using one of the two threshold: `wait_ratio_threshold` and `ẁait_time_threshold`
 
 The diversion check is done only once per call, before the
-[preprocess subroutine](/uc-doc/api_sdk/subroutine) is
-executed and before the call enters the queue.
+[preprocess subroutine](/uc-doc/api_sdk/subroutine) is executed and before the call enters the
+queue.
 
 ### `wait_time_threshold`
 
-When this scenario is used, the administrator can set a destination for
-calls to be sent to when the estimated waiting time is over the
-threshold `wait_time_threshold`.
+When this scenario is used, the administrator can set a destination for calls to be sent to when the
+estimated waiting time is over the threshold `wait_time_threshold`.
 
-Note that if a new call arrives when there are no waiting calls in the
-queue, the call will **always** be allowed to enter the queue.
+Note that if a new call arrives when there are no waiting calls in the queue, the call will
+**always** be allowed to enter the queue.
 
 #:exclamation:
 
--   this *estimated* waiting time is computed from the **actual hold
-    time** of all **answered** calls in the queue (since last asterisk
-    restart) according to an [exponential smoothing
-    formula](https://en.wikipedia.org/wiki/Exponential_smoothing)
--   the estimated waiting time of a queue is updated only when a queue
-    member answers a call.
+- this _estimated_ waiting time is computed from the **actual hold time** of all **answered** calls
+  in the queue (since last asterisk restart) according to an
+  [exponential smoothing formula](https://en.wikipedia.org/wiki/Exponential_smoothing)
+- the estimated waiting time of a queue is updated only when a queue member answers a call.
 
 ### `wait_ratio_threshold` {#queue-diversion-waitratio}
 
-When this scenario is used, the administrator can set a destination for
-calls to be sent to when the number of waiting calls per logged-in agent
-is over the `wait_ratio_threshold`.
+When this scenario is used, the administrator can set a destination for calls to be sent to when the
+number of waiting calls per logged-in agent is over the `wait_ratio_threshold`.
 
-The number of waiting calls includes the call for which the check is
-currently being performed.
+The number of waiting calls includes the call for which the check is currently being performed.
 
-The number of logged-in agents is the sum of user members and currently
-logged-in agent members. An agent only needs to be logged in and a
-member of the queue to participate towards the count of logged-in
-agents, regardless of whether he is available, on call, on pause or on
-wrapup.
+The number of logged-in agents is the sum of user members and currently logged-in agent members. An
+agent only needs to be logged in and a member of the queue to participate towards the count of
+logged-in agents, regardless of whether he is available, on call, on pause or on wrapup.
 
-The maximum number of waiting calls per logged-in agent can have a
-fractional part.
+The maximum number of waiting calls per logged-in agent can have a fractional part.
 
 Here are a few examples:
 
@@ -129,35 +105,31 @@ Here are a few examples:
     Number of waiting calls per logged-in agent when a new call arrives: 6 / 12 = 0.5
     Call will not be redirected to ``wait_ratio_destination``
 
-Note that if a new call arrives when there are no waiting calls in the
-queue, the call will **always** be allowed to enter the queue. For
-example, in the following scenario:
+Note that if a new call arrives when there are no waiting calls in the queue, the call will
+**always** be allowed to enter the queue. For example, in the following scenario:
 
     wait_ratio_threshold: 0.5
     Current number of waiting calls: 0
     Current number of logged-in agents: 1
     Number of waiting calls per logged-in agent when a new call arrives: 1 / 1 = 1
 
-Even if `wait_ratio_time` (1) is greater than the maximum (0.5), the
-call will still be accepted since there are currently no waiting calls.
+Even if `wait_ratio_time` (1) is greater than the maximum (0.5), the call will still be accepted
+since there are currently no waiting calls.
 
 ## Music on Hold {#moh}
 
 The `music_on_hold` of the queue will be played:
 
--   When the caller is waiting to be answered.
--   When the caller is put on hold by an agent who already answered.
+- When the caller is waiting to be answered.
+- When the caller is put on hold by an agent who already answered.
 
-If you want a different music to be played when the caller is put on
-hold after being answered, you need to make some more configuration:
+If you want a different music to be played when the caller is put on hold after being answered, you
+need to make some more configuration:
 
-1.  Write an AGI script that will set the channel variable
-    `CHANNEL(musicclass)` to the name of the music-on-hold class you
-    want the caller to hear when he is put on hold by the agent. Save
-    this script to e.g. `/usr/local/bin/agi-agent-hold-moh`.
-2.  Add the following
-    [preprocess subroutine](/uc-doc/api_sdk/subroutine)
-    on the queue:
+1.  Write an AGI script that will set the channel variable `CHANNEL(musicclass)` to the name of the
+    music-on-hold class you want the caller to hear when he is put on hold by the agent. Save this
+    script to e.g. `/usr/local/bin/agi-agent-hold-moh`.
+2.  Add the following [preprocess subroutine](/uc-doc/api_sdk/subroutine) on the queue:
 
         [setup-agent-hold-moh]
         exten = s,1,NoOp(Setting AGI script for custom agent hold music)
@@ -166,10 +138,10 @@ hold after being answered, you need to make some more configuration:
 
 This configuration will give the following scenario:
 
--   The caller calls the queue
--   The caller hears the music on hold of the queue
--   The agent answers the call
--   Wazo calls the AGI script, setting the new music on hold
--   The caller and the agent talk together
--   The agent puts the caller on hold
--   The caller hears the new music on hold, set by the AGI script
+- The caller calls the queue
+- The caller hears the music on hold of the queue
+- The agent answers the call
+- Wazo calls the AGI script, setting the new music on hold
+- The caller and the agent talk together
+- The agent puts the caller on hold
+- The caller hears the new music on hold, set by the AGI script

--- a/content/uc-doc/contact_center/reporting.md
+++ b/content/uc-doc/contact_center/reporting.md
@@ -2,160 +2,150 @@
 title: Reporting
 ---
 
-You may use your own reporting tools to be able to produce your own
-reports provided **you do not use the Wazo server original tables**, but
-copy the tables to your own data server. You may use the following
-procedure as a template :
+You may use your own reporting tools to be able to produce your own reports provided **you do not
+use the Wazo server original tables**, but copy the tables to your own data server. You may use the
+following procedure as a template :
 
--   Allow remote database access on Wazo
--   Create a postgresql account read only on asterisk database
--   Create target tables in your database located on the data server
--   Copy the statistic table content to your data server
+- Allow remote database access on Wazo
+- Create a postgresql account read only on asterisk database
+- Create target tables in your database located on the data server
+- Copy the statistic table content to your data server
 
-General Architecture {#general-architecture}
-====================
+# General Architecture {#general-architecture}
 
 ![Statistics Architecture](/images/uc-doc/contact_center/reporting/archi.png)
 
-1.  The *queue\_log* table of the *asterisk* database is filled by
-    events from Asterisk and by custom dialplan events
-2.  *xivo-stat fill\_db* is then used to read data from the *queue\_log*
-    table and generate the tables *stat\_call\_on\_queue* and
-    *stat\_queue\_periodic*
+1.  The _queue_log_ table of the _asterisk_ database is filled by events from Asterisk and by custom
+    dialplan events
+2.  _xivo-stat fill_db_ is then used to read data from the _queue_log_ table and generate the tables
+    _stat_call_on_queue_ and _stat_queue_periodic_
 
-Statistic Data Table Content {#statistic-data-table-content}
-============================
+# Statistic Data Table Content {#statistic-data-table-content}
 
-stat\_call\_on\_queue {#stat-call-on-queue}
----------------------
+## stat_call_on_queue {#stat-call-on-queue}
 
-This table is used to store each call individually. Each call received
-on a queue generates a single entry in this table containing time
-related fields and a foreign key to the agent who answered the call and
-another on the queue on which the call was received.
+This table is used to store each call individually. Each call received on a queue generates a single
+entry in this table containing time related fields and a foreign key to the agent who answered the
+call and another on the queue on which the call was received.
 
-It also contains the status of the call ie. answered, abandoned, full,
-etc.
+It also contains the status of the call ie. answered, abandoned, full, etc.
 
-  --------------------------------------------------------------------------------
-  Field       Values      Description
-  ----------- ----------- --------------------------------------------------------
-  id          generated
+---
 
-  callid      numeric     This call id is also used in the CEL table and can be
-              value       used to get call detail information
+Field Values Description
 
-  time        Call time
+---
 
-  ringtime                Ringing duration time in seconds
+id generated
 
-  talktime                Talk time duration in seconds
+callid numeric This call id is also used in the CEL table and can be value used to get call detail
+information
 
-  waittime                Wait time duration in seconds
+time Call time
 
-  status                  See status description below
+ringtime Ringing duration time in seconds
 
-  queue\_id               Id of the queue, the name of the queue can be found in
-                          table `stat_queue`, using this name queue details can be
-                          found in table `queuefeatures`
+talktime Talk time duration in seconds
 
-  agent\_id               Id of the agent, the agent name can be found in table
-                          `stat_agent`, using this name agent details can be found
-                          in table `agentfeatures` using the number in the second
-                          part of the name Exemple : Agent/1002 is agent with
-                          number 1002 in table `agentfeatures`
-  --------------------------------------------------------------------------------
+waittime Wait time duration in seconds
 
-Queue Call Status {#queue-call-status}
------------------
+status See status description below
 
-  --------------------------------------------------------------------------------
-  Status              Description
-  ------------------- ------------------------------------------------------------
-  full                Call was not queued because queue was full, happens when the
-                      number of calls is greater than the maximum number of calls
-                      allowed to wait
+queue_id Id of the queue, the name of the queue can be found in table `stat_queue`, using this name
+queue details can be found in table `queuefeatures`
 
-  closed              Closed due to the schedule applied to the queue
+agent_id Id of the agent, the agent name can be found in table `stat_agent`, using this name agent
+details can be found in table `agentfeatures` using the number in the second part of the name
+Exemple : Agent/1002 is agent with number 1002 in table `agentfeatures`
 
-  joinempty           No agents were available in the queue to take the call
-                      (follows the join empty parameter of the queue)
+---
 
-  leaveempty          No agents available while the call was waiting in the qeuue
+## Queue Call Status {#queue-call-status}
 
-  divert\_ca\_ratio   Call diverted because the ratio number of agent number of
-                      calls waiting configured was exceeded
+---
 
-  divert\_waittime    Call diverted because the maximum expected waiting time
-                      configured was exceeded
+Status Description
 
-  answered            Call was answered
+---
 
-  abandoned           Call hangup by the caller
+full Call was not queued because queue was full, happens when the number of calls is greater than
+the maximum number of calls allowed to wait
 
-  timeout             Call stayed longer than the maximum time allowed in queue
-                      parameter
-  --------------------------------------------------------------------------------
+closed Closed due to the schedule applied to the queue
 
-stat\_queue\_periodic Table {#stat-queue-periodic-table}
----------------------------
+joinempty No agents were available in the queue to take the call (follows the join empty parameter
+of the queue)
 
-This table is an aggregation of the queue\_log table.
+leaveempty No agents available while the call was waiting in the qeuue
 
-This table contains counters on each queue for each given period. The
-granularity at the time of this writing is an hour and is not
-configurable. This table is then used to compute statistics for a given
-range of hours, days, week, month or year.
+divert_ca_ratio Call diverted because the ratio number of agent number of calls waiting configured
+was exceeded
 
-  --------------------------------------------------------------------------------
-  Field               Description
-  ------------------- ------------------------------------------------------------
-  id                  Generated id
+divert_waittime Call diverted because the maximum expected waiting time configured was exceeded
 
-  time                time period, all counters are aggregated for an hour
+answered Call was answered
 
-  answered            Number of answered calls during the period
+abandoned Call hangup by the caller
 
-  abandoned           Number of abandoned calls during the period
+timeout Call stayed longer than the maximum time allowed in queue parameter
 
-  total               Total calls received during the period
+---
 
-  full                Number of calls received when queue was full
+## stat_queue_periodic Table {#stat-queue-periodic-table}
 
-  closed              Number of calls received on close
+This table is an aggregation of the queue_log table.
 
-  joinempty           Number of calls received no agents available
+This table contains counters on each queue for each given period. The granularity at the time of
+this writing is an hour and is not configurable. This table is then used to compute statistics for a
+given range of hours, days, week, month or year.
 
-  leaveempty          Number of calls diverted agents not available during the
-                      wait
+---
 
-  divert\_ca\_ratio   Number of calls diverted due to the number of agent number
-                      versus calls waiting configured was exceeded
+Field Description
 
-  divert\_waittime    Number of calls diverted because the maximum expected
-                      waiting time configured was exceeded
+---
 
-  timeout             Number of calls diverted because the maximum time allowed in
-                      queue parameter was exceeded
+id Generated id
 
-  queue\_id
-  --------------------------------------------------------------------------------
+time time period, all counters are aggregated for an hour
 
-stat\_agent {#stat-agent}
------------
+answered Number of answered calls during the period
 
-This table is used to match agents to an id that is different from the
-id in the agent configuration table. This is necessary to avoid loosing
-statistics on a deleted agent. This also means that if an agent changes
-number ie. Agent/1001 to Agent/1202, the supervisor will have to take
-this information into account when viewing the statistics. Affecting an
-old number to a another agent also means that the supervisor will have
-to ignore entries for this given agent for the period before the number
+abandoned Number of abandoned calls during the period
+
+total Total calls received during the period
+
+full Number of calls received when queue was full
+
+closed Number of calls received on close
+
+joinempty Number of calls received no agents available
+
+leaveempty Number of calls diverted agents not available during the wait
+
+divert_ca_ratio Number of calls diverted due to the number of agent number versus calls waiting
+configured was exceeded
+
+divert_waittime Number of calls diverted because the maximum expected waiting time configured was
+exceeded
+
+timeout Number of calls diverted because the maximum time allowed in queue parameter was exceeded
+
+queue_id
+
+---
+
+## stat_agent {#stat-agent}
+
+This table is used to match agents to an id that is different from the id in the agent configuration
+table. This is necessary to avoid loosing statistics on a deleted agent. This also means that if an
+agent changes number ie. Agent/1001 to Agent/1202, the supervisor will have to take this information
+into account when viewing the statistics. Affecting an old number to a another agent also means that
+the supervisor will have to ignore entries for this given agent for the period before the number
 assignment to the new agent.
 
-stat\_queue {#stat-queue}
------------
+## stat_queue {#stat-queue}
 
-This table is used to store queues in a table that is different from the
-queue configuration table. This is necessary to avoid losing statistics
-on a deleted queue. Renaming a queue is also not handled at this time.
+This table is used to store queues in a table that is different from the queue configuration table.
+This is necessary to avoid losing statistics on a deleted queue. Renaming a queue is also not
+handled at this time.

--- a/content/uc-doc/contact_center/reporting.md
+++ b/content/uc-doc/contact_center/reporting.md
@@ -2,14 +2,6 @@
 title: Reporting
 ---
 
--   [General Architecture](#general-architecture)
--   [Statistic Data Table Content](#statistic-data-table-content)
-    -   [stat\_call\_on\_queue](#stat-call-on-queue)
-    -   [Queue Call Status](#queue-call-status)
-    -   [stat\_queue\_periodic Table](#stat-queue-periodic-table)
-    -   [stat\-agent](#stat-agent)
-    -   [stat\-queue](#stat-queue)
-
 You may use your own reporting tools to be able to produce your own
 reports provided **you do not use the Wazo server original tables**, but
 copy the tables to your own data server. You may use the following

--- a/content/uc-doc/contact_center/skillbasedrouting.md
+++ b/content/uc-doc/contact_center/skillbasedrouting.md
@@ -2,20 +2,6 @@
 title: 'Skills-Based Routing'
 ---
 
--   [Introduction](#introduction)
--   [Getting Started](#getting-started)
--   [Skills](#skills)
--   [Skill Rule Sets](#skill-rule-sets)
-    -   [Scenario 1](#scenario-1)
-    -   [Scenario 2](#scenario-2)
-    -   [Rules](#rules)
-    -   [Operators](#operators)
-    -   [Dynamic Part](#skill-dynamic-part)
-    -   [Skill Part](#skill-skill-part)
-    -   [Evaluation](#skill-evaluation)
--   [Apply Skill Rule Sets](#skill-apply)
--   [Monitoring](#monitoring)
-
 Introduction
 ============
 

--- a/content/uc-doc/contact_center/skillbasedrouting.md
+++ b/content/uc-doc/contact_center/skillbasedrouting.md
@@ -2,193 +2,165 @@
 title: 'Skills-Based Routing'
 ---
 
-Introduction
-============
+# Introduction
 
-> *Skills-based routing (SBR), or Skills-based call routing, is a
-> call-assignment strategy used in call centres to assign incoming calls
-> to the most suitable agent, instead of simply choosing the next
-> available agent. It is an enhancement to the Automatic Call
-> Distributor (ACD) systems found in most call centres. The need for
-> skills-based routing has arisen, as call centres have become larger
-> and dealt with a wider variety of call types.*
+> _Skills-based routing (SBR), or Skills-based call routing, is a call-assignment strategy used in
+> call centres to assign incoming calls to the most suitable agent, instead of simply choosing the
+> next available agent. It is an enhancement to the Automatic Call Distributor (ACD) systems found
+> in most call centres. The need for skills-based routing has arisen, as call centres have become
+> larger and dealt with a wider variety of call types._
 >
 > \-- Wikipedia
 
-In this respect, skills-based routing is also based on call distribution
-to agents through waiting queues, but one or many skills can be assigned
-to each agent, and call can be distributed to the most suitable agent.
+In this respect, skills-based routing is also based on call distribution to agents through waiting
+queues, but one or many skills can be assigned to each agent, and call can be distributed to the
+most suitable agent.
 
-In skills-based routing, you will have to find a way to be able to tag
-the call for a specific skill need. This can be done for example by
-entering the call distribution system using different incoming call
-numbers, using an IVR to let the caller do his own choice, or by
-requesting to the information system database the customer profile.
+In skills-based routing, you will have to find a way to be able to tag the call for a specific skill
+need. This can be done for example by entering the call distribution system using different incoming
+call numbers, using an IVR to let the caller do his own choice, or by requesting to the information
+system database the customer profile.
 
 ![Skills-Based Routing](/images/uc-doc/contact_center/skillbasedrouting/sbr_introduction.png)
 
-Getting Started
-===============
+# Getting Started
 
--   Create the skills
--   Apply the skills to the agents
--   Create the skill rule sets
--   Assign the skill rule sets using a configuration file
--   Apply the skill rule sets to call qualification
+- Create the skills
+- Apply the skills to the agents
+- Create the skill rule sets
+- Assign the skill rule sets using a configuration file
+- Apply the skill rule sets to call qualification
 
-Note that you shouldn\'t use skill based routing on a queue with queue
-members of type user because the behaviour is not defined and might
-change in a future Wazo version.
+Note that you shouldn\'t use skill based routing on a queue with queue members of type user because
+the behaviour is not defined and might change in a future Wazo version.
 
-Skills
-======
+# Skills
 
 Skills are created using:
 
--   `POST /agents/skills`
+- `POST /agents/skills`
 
-Once all the skills are created you may apply them to agents. Agents may
-have one or more skills.
+Once all the skills are created you may apply them to agents. Agents may have one or more skills.
 
--   `PUT /agents/{agent_id}/skills/{skill_id} {"skill_weight": 55}`
+- `PUT /agents/{agent_id}/skills/{skill_id} {"skill_weight": 55}`
 
-It is typical to use a value between 0 and 100 inclusively as the
-`skill_weight`, although any integer is accepted.
+It is typical to use a value between 0 and 100 inclusively as the `skill_weight`, although any
+integer is accepted.
 
-Skill Rule Sets
-===============
+# Skill Rule Sets
 
 Once skills are created, rule sets can be defined.
 
--   `POST /queues/skillrules`
+- `POST /queues/skillrules`
 
-A rule set is a list of rules. Here\'s an example of a rule set
-containing 2 rules:
+A rule set is a list of rules. Here\'s an example of a rule set containing 2 rules:
 
 1.  WT \< 60, english \> 50
 2.  english \> 0
 
 The first rule of this rule set can be read as:
 
-> If the caller has been waiting for less than 60 seconds (WT \< 60),
-> only try to call agents which have the skill \"english\" set to a
-> value higher than 50; otherwise, go to the next rule.
+> If the caller has been waiting for less than 60 seconds (WT \< 60), only try to call agents which
+> have the skill \"english\" set to a value higher than 50; otherwise, go to the next rule.
 
 And the second rule can be read as:
 
-> Only try to call agents which have the skill \"english\" set to a
-> value higher than 0.
+> Only try to call agents which have the skill \"english\" set to a value higher than 0.
 
-Let\'s examine some simple scenarios, because there\'s actually some
-subtleties on how calls are distributed. We will suppose that we have a
-queue with the default settings and the following members:
+Let\'s examine some simple scenarios, because there\'s actually some subtleties on how calls are
+distributed. We will suppose that we have a queue with the default settings and the following
+members:
 
--   Agent A, with skill english set to 75
--   Agent B, with skill english set to 25
+- Agent A, with skill english set to 75
+- Agent B, with skill english set to 25
 
-Scenario 1
-----------
+## Scenario 1
 
 Given:
 
--   Agent A is logged and not in use
--   Agent B is logged and not in use
--   There is no call in the queue
+- Agent A is logged and not in use
+- Agent B is logged and not in use
+- There is no call in the queue
 
-When a new call enters the queue, then it is distributed to Agent A. As
-long as Agent A is available and doesn\'t answer the call, the call will
-never be distributed to Agent B, even after 60 seconds of waiting time.
+When a new call enters the queue, then it is distributed to Agent A. As long as Agent A is available
+and doesn\'t answer the call, the call will never be distributed to Agent B, even after 60 seconds
+of waiting time.
 
-When another call enters the queue, then after 60 seconds of waiting
-time, this call will be distributed to Agent B (and the first call will
-still be distributed only to Agent A).
+When another call enters the queue, then after 60 seconds of waiting time, this call will be
+distributed to Agent B (and the first call will still be distributed only to Agent A).
 
-The reason is that there\'s a difference between a call that is being
-distributed (i.e. that is making agents ring) and a call that is waiting
-for being distributed. When a call is being distributed to a set of
-members, no other rule is tried as long as there\'s at least 1 of these
+The reason is that there\'s a difference between a call that is being distributed (i.e. that is
+making agents ring) and a call that is waiting for being distributed. When a call is being
+distributed to a set of members, no other rule is tried as long as there\'s at least 1 of these
 members available.
 
-Scenario 2
-----------
+## Scenario 2
 
 Given:
 
--   Agent A is not logged
--   Agent B is logged and not in use
--   There is no call in the queue
+- Agent A is not logged
+- Agent B is logged and not in use
+- There is no call in the queue
 
-When a new call enters the queue, then it is *immediately* distributed
-to Agent B.
+When a new call enters the queue, then it is _immediately_ distributed to Agent B.
 
-The reason is that when there\'s no logged agent matching a rule, the
-next rule is immediately tried.
+The reason is that when there\'s no logged agent matching a rule, the next rule is immediately
+tried.
 
-Rules
------
+## Rules
 
-Each rule set is composed of rules, and each rule has two parts,
-separated by a comma:
+Each rule set is composed of rules, and each rule has two parts, separated by a comma:
 
--   the first part (optional) is the
-    ["dynamic part"](/uc-doc/contact_center/skillbasedrouting#skill-dynamic-part)
--   the second part is the
-    ["skill part"](/uc-doc/contact_center/skillbasedrouting#skill-skill-part)
+- the first part (optional) is the
+  ["dynamic part"](/uc-doc/contact_center/skillbasedrouting#skill-dynamic-part)
+- the second part is the ["skill part"](/uc-doc/contact_center/skillbasedrouting#skill-skill-part)
 
-Each part contains an expression composed of operators, variables and
-integer constants.
+Each part contains an expression composed of operators, variables and integer constants.
 
-Operators
----------
+## Operators
 
 The following operators can be used inside rules:
 
 Comparison operators:
 
--   operand1 ! operand2 (is not equal)
--   operand1 = operand2 (is equal)
--   operand1 \> operand2 (is greater than)
--   operand1 \< operand2 (is lesser than)
+- operand1 ! operand2 (is not equal)
+- operand1 = operand2 (is equal)
+- operand1 \> operand2 (is greater than)
+- operand1 \< operand2 (is lesser than)
 
 Logical operators:
 
--   operand1 & operand2 (both are true)
--   operand1 \| operand2 (at least one of them are true)
+- operand1 & operand2 (both are true)
+- operand1 \| operand2 (at least one of them are true)
 
-\'!\' is the operator with the higher priority, and \'\|\' the one with
-the lower priority. You can use parentheses \'()\' to change the
-priority of operations.
+\'!\' is the operator with the higher priority, and \'\|\' the one with the lower priority. You can
+use parentheses \'()\' to change the priority of operations.
 
-Dynamic Part {#skill-dynamic-part}
-------------
+## Dynamic Part {#skill-dynamic-part}
 
 The dynamic part can reference the following variables:
 
--   WT
--   EWT
+- WT
+- EWT
 
-The waiting time (WT) is the elapsed time since the call entered the
-queue. The time the call pass in an IVR or another queue is not taken
-into account.
+The waiting time (WT) is the elapsed time since the call entered the queue. The time the call pass
+in an IVR or another queue is not taken into account.
 
-The estimated waiting time (EWT) has never fully worked. It is mentioned
-here only for historical reason. You should not use it. It might be
-removed in a future Wazo version.
+The estimated waiting time (EWT) has never fully worked. It is mentioned here only for historical
+reason. You should not use it. It might be removed in a future Wazo version.
 
 Examples
 
 :
 
--   WT \< 60
+- WT \< 60
 
-Skill Part {#skill-skill-part}
-----------
+## Skill Part {#skill-skill-part}
 
 The skill part can reference any skills name as variables.
 
-You can also use meta-variables, starting with a \'\$\', to substitute
-them with data set on the Queue() call. For example, if you call Queue()
-with the skill rule set argument equal to:
+You can also use meta-variables, starting with a \'\$\', to substitute them with data set on the
+Queue() call. For example, if you call Queue() with the skill rule set argument equal to:
 
     select_lang(lang=german)
 
@@ -198,12 +170,10 @@ Examples
 
 :
 
--   english \> 50
--   technic ! 0 & (\$os \> 29 & \$lang \> 39 \| \$os \> 39 &
-    \$lang \> 19)
+- english \> 50
+- technic ! 0 & (\$os \> 29 & \$lang \> 39 \| \$os \> 39 & \$lang \> 19)
 
-Evaluation {#skill-evaluation}
-----------
+## Evaluation {#skill-evaluation}
 
 Note that the expression:
 
@@ -213,63 +183,59 @@ is equivalent to:
 
 > english ! 0 \| french ! 0
 
-Sometimes, a rule references a skill which is not defined for every
-agent. For example, given the following rule:
+Sometimes, a rule references a skill which is not defined for every agent. For example, given the
+following rule:
 
 > english \> 0 \| english \< 1
 
-Then, for an agent which has the skill english defined, the result of
-this expression is always true. For an agent which does not have the
-skill english defined, the result of this expression is always false.
+Then, for an agent which has the skill english defined, the result of this expression is always
+true. For an agent which does not have the skill english defined, the result of this expression is
+always false.
 
-Said differently, an agent without a skill X is not the same as an agent
-with the skill X set to the value 0.
+Said differently, an agent without a skill X is not the same as an agent with the skill X set to the
+value 0.
 
-Technically, this is what is happening when evaluating the rule
-\"english \> 0\" for an agent without the skill english:
+Technically, this is what is happening when evaluating the rule \"english \> 0\" for an agent
+without the skill english:
 
     english > 0
 
 > = \<Substituing english with the agent value\>
 >
-> :   \"undefined\" \> 0
+> : \"undefined\" \> 0
 >
 > = \<A comparison with \"undefined\" in at least one operand yields undefined\>
 >
-> :   \"undefined\"
+> : \"undefined\"
 >
 > = \<In a boolean context, \"undefined\" is equal to false\>
 >
-> :   false
+> : false
 >
-This behaviour applies to every comparison operators.
+> This behaviour applies to every comparison operators.
 
-Also, the syntax that is currently accepted for comparison is always of
-the form:
+Also, the syntax that is currently accepted for comparison is always of the form:
 
     variable cmp_op constant
 
-Where \"variable\" is a variable name, \"cmp\_op\" is a comparison
-operator and \"constant\" is an integer constant. This means the
-following expressions are not accepted:
+Where \"variable\" is a variable name, \"cmp_op\" is a comparison operator and \"constant\" is an
+integer constant. This means the following expressions are not accepted:
 
--   10 \< english (but english \> 10 is accepted)
--   english \< french (the second operand must be a constant)
--   10 \< 11 (the first operand must be a variable name)
+- 10 \< english (but english \> 10 is accepted)
+- english \< french (the second operand must be a constant)
+- 10 \< 11 (the first operand must be a variable name)
 
-Apply Skill Rule Sets {#skill-apply}
-=====================
+# Apply Skill Rule Sets {#skill-apply}
 
 A skill rule set is attached to a call using an incoming call.
 
--   `POST incalls {"destination": {"type": "queue", "skill_rule_id": <id>, "skill_rule_variables": {"lang": "english"}}}`
--   `POST incalls {"destination": {"type": "queue", "skill_rule_id": <id>, "skill_rule_variables": {"lang": "french"}}}`
+- `POST incalls {"destination": {"type": "queue", "skill_rule_id": <id>, "skill_rule_variables": {"lang": "english"}}}`
+- `POST incalls {"destination": {"type": "queue", "skill_rule_id": <id>, "skill_rule_variables": {"lang": "french"}}}`
 
-Monitoring
-==========
+# Monitoring
 
-You may monitor your waiting calls with skills using the asterisk CLI
-and the command `queue show <queue_name>`:
+You may monitor your waiting calls with skills using the asterisk CLI and the command
+`queue show <queue_name>`:
 
     wazo*CLI> queue show services
     services has 1 calls (max unlimited) in 'ringall' strategy (0s holdtime, 2s talktime), W:0, C:1, A:10, SL:0.0% within 0s
@@ -281,8 +247,7 @@ and the command `queue show <queue_name>`:
          1. SIP/jyl-dev-assur-00000017 (wait: 0:05, prio: 0)
       Callers:
 
-You may monitor your skills groups with the command
-`queue show skills groups <agent_name>`:
+You may monitor your skills groups with the command `queue show skills groups <agent_name>`:
 
     wazo*CLI> queue show skills groups <PRESS TAB>
     agent-2   agent-3   agent-4   agent-48  agent-7   agent-1
@@ -291,8 +256,7 @@ You may monitor your skills groups with the command
       - bank           : 50
       - english        : 100
 
-You may monitor your skills rules with the command
-`queue show skills rules <rule_name>`:
+You may monitor your skills rules with the command `queue show skills rules <rule_name>`:
 
     wazo*CLI> queue show skills rules <PRESS TAB>
     english      french       select_lang


### PR DESCRIPTION
- Fix 404 in index page
- Remove useless table of content on top of the pages
- Convert titles to markdown format
- Improve introduction page a bit
- Reformat content for contact center (aka run `yarn format:uc-doc`)