### PR TITLE
rebuild plantuml files only if necessary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY --from=build-node /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 # Install Git
 RUN apk update && apk upgrade && \
-    apk add --no-cache git
+    apk add --no-cache git make
 
 # Move plantuml to a folder in the PATH
 RUN mv /plantuml.jar "$JAVA_HOME/lib"

--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,22 @@ clean:
 import:
 	./import-plantuml.sh
 
-.PHONY: builder build develop format test clean import
+DIAGRAM_DIRECTORY=public/diagrams
+plantuml-diagrams:
+	mkdir -p $(DIAGRAM_DIRECTORY)
+	for f in $$(find content -name '*.puml'|grep -v /plantuml/); do \
+		cp -p $$f $(DIAGRAM_DIRECTORY)/$$(basename $$(dirname $$f))-$$(basename $$f); \
+	done
+	$(MAKE) plantuml-run
+	rm -f $(DIAGRAM_DIRECTORY)/*.puml
+
+plantuml-run:
+	outputs="$(patsubst %.puml,%.svg,$(wildcard $(DIAGRAM_DIRECTORY)/*.puml))"; \
+	cp content/plantuml/*.puml $(DIAGRAM_DIRECTORY); \
+	$(MAKE) $${outputs}
+
+%.svg: %.puml
+	java -jar ${JAVA_HOME}/lib/plantuml.jar -tsvg -o$(DIAGRAM_DIRECTORY) $^
+
+
+.PHONY: builder build develop format test clean import plantuml-diagrams

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,4 +13,5 @@ services:
       - ./gatsby-config.js:/app/gatsby-config.js:ro
       - ./config.js:/app/config.js:ro
       - ./tests:/app/tests:ro
+      - ./Makefile:/app/Makefile:ro
     command: sleep 3600 # Use to let container up during build

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -229,15 +229,11 @@ exports.createPages = async ({ graphql, actions: { createPage, createRedirect } 
 
   // Retrieve all diagrams
   const diagramOutputDir = path.resolve('public/diagrams/');
-  execSync(`mkdir -p ${diagramOutputDir}`);
-  execSync(`rm -rf ${diagramOutputDir}/*`);
   walk('content');
 
   // Generate puml to svg
   console.info(`generating svg diagrams in ${diagramOutputDir}...`);
-  execSync(
-    `set -e; cp content/plantuml/* ${diagramOutputDir}/; for f in $(find content -name '*.puml'|grep -v /plantuml/); do cp $f ${diagramOutputDir}/$(basename $(dirname $f))-$(basename $f); done; java -jar $JAVA_HOME/lib/plantuml.jar -tsvg ${diagramOutputDir}/*.puml; rm -f ${diagramOutputDir}/*.puml`
-  );
+  const output = execSync(`make plantuml-diagrams DIAGRAM_DIRECTORY=${diagramOutputDir}`);
   console.info(`done generating svg diagrams`);
 
   // Create homepage


### PR DESCRIPTION
Why:

* Rebuilding the PlantUML files takes a long time
* It is unnecessary if the PlantUML files did not change

How:

* Use `make` to rebuild only if the .svg file is older than the .puml file
