### PR TITLE
user import: fix field names

### DIFF
--- a/content/uc-doc/administration/users/csv_import.md
+++ b/content/uc-doc/administration/users/csv_import.md
@@ -27,66 +27,66 @@ created and associated to its user when all required fields for that resource ar
 
 #### User
 
-| Field                                 | Type   | Required | Values                            | Description                                                            |
-| ------------------------------------- | ------ | -------- | --------------------------------- | ---------------------------------------------------------------------- |
-| firstname                             | string | Yes      |                                   | User's firstname                                                       |
-| lastname                              | string |          |                                   | User's lastname                                                        |
-| email                                 | string |          |                                   | User's email                                                           |
-| language                              | string |          | de_DE, en_US, es_ES, fr_FR, fr_CA | User's language                                                        |
-| mobile_phone_number                   | string |          |                                   | Mobile phone number                                                    |
-| outgoing_caller_id                    | string |          |                                   | Customize outgoing caller id for this user                             |
-| enabled                               | bool   |          |                                   | Enable/Disable the user                                                |
-| supervision_enabled                   | bool   |          |                                   | Enable/Disable supervision                                             |
-| call_record_outgoing_external_enabled | bool   |          |                                   | Enable/Disable all external calls made by this user                    |
-| call_record_outgoing_internal_enabled | bool   |          |                                   | Enable/Disable all internal calls made by this user                    |
-| call_record_incoming_external_enabled | bool   |          |                                   | Enable/Disable all external calls received by this user                |
-| call_record_incoming_internal_enabled | bool   |          |                                   | Enable/Disable all internal calls received by this user                |
-| call_transfer_enabled                 | bool   |          |                                   | Enable/Disable call transfers by DTMF                                  |
-| dtmf_hangup_enabled                   | bool   |          |                                   | Enable/Disable hangup by DTMF                                          |
-| simultaneous_calls                    | int    |          |                                   | Number of calls a user can have on his phone simultaneously            |
-| ring_seconds                          | int    |          | A multiple of 5                   | Seconds a call ring before ending                                      |
-| call_permission_password              | string |          |                                   | Overwrite all passwords set in call permissions associated to the user |
-| username                              | string |          |                                   | User's username to log into applications                               |
-| password                              | string |          |                                   | User's password to log into applications                               |
-| userfield                             | string |          |                                   | A custom field which purpose is left to the client                     |
-| subscription_type                     | int    |          |                                   | The subscription type for this user                                    |
+| Field                                   | Type   | Required | Values                                      | Description                                                            |
+| --------------------------------------- | ------ | -------- | ------------------------------------------- | ---------------------------------------------------------------------- |
+| `firstname`                             | string | Yes      |                                             | User's firstname                                                       |
+| `lastname`                              | string |          |                                             | User's lastname                                                        |
+| `email`                                 | string |          |                                             | User's email                                                           |
+| `language`                              | string |          | `de_DE`, `en_US`, `es_ES`, `fr_FR`, `fr_CA` | User's language                                                        |
+| `mobile_phone_number`                   | string |          |                                             | Mobile phone number                                                    |
+| `outgoing_caller_id`                    | string |          |                                             | Customize outgoing caller id for this user                             |
+| `enabled`                               | bool   |          |                                             | Enable/Disable the user                                                |
+| `supervision_enabled`                   | bool   |          |                                             | Enable/Disable supervision                                             |
+| `call_record_outgoing_external_enabled` | bool   |          |                                             | Enable/Disable all external calls made by this user                    |
+| `call_record_outgoing_internal_enabled` | bool   |          |                                             | Enable/Disable all internal calls made by this user                    |
+| `call_record_incoming_external_enabled` | bool   |          |                                             | Enable/Disable all external calls received by this user                |
+| `call_record_incoming_internal_enabled` | bool   |          |                                             | Enable/Disable all internal calls received by this user                |
+| `call_transfer_enabled`                 | bool   |          |                                             | Enable/Disable call transfers by DTMF                                  |
+| `dtmf_hangup_enabled`                   | bool   |          |                                             | Enable/Disable hangup by DTMF                                          |
+| `simultaneous_calls`                    | int    |          |                                             | Number of calls a user can have on his phone simultaneously            |
+| `ring_seconds`                          | int    |          | A multiple of 5                             | Seconds a call ring before ending                                      |
+| `call_permission_password`              | string |          |                                             | Overwrite all passwords set in call permissions associated to the user |
+| `username`                              | string |          |                                             | User's username to log into applications                               |
+| `password`                              | string |          |                                             | User's password to log into applications                               |
+| `userfield`                             | string |          |                                             | A custom field which purpose is left to the client                     |
+| `subscription_type`                     | int    |          |                                             | The subscription type for this user                                    |
 
 #### Phone
 
-| Field         | Type   | Required | Values            | Description                                                                                                    |
-| ------------- | ------ | -------- | ----------------- | -------------------------------------------------------------------------------------------------------------- |
-| exten         | string | Yes      |                   | Number for calling the user. The number must be inside the range of acceptable numbers defined for the context |
-| context       | string | Yes      |                   | Context                                                                                                        |
-| line_protocol | string | Yes      | sip, sccp, webrtc | Line protocol                                                                                                  |
-| sip_username  | string |          |                   | SIP username                                                                                                   |
-| sip_secret    | string |          |                   | SIP secret                                                                                                     |
+| Field           | Type   | Required | Values            | Description                                                                                                    |
+| --------------- | ------ | -------- | ----------------- | -------------------------------------------------------------------------------------------------------------- |
+| `exten`         | string | Yes      |                   | Number for calling the user. The number must be inside the range of acceptable numbers defined for the context |
+| `context`       | string | Yes      |                   | Context                                                                                                        |
+| `line_protocol` | string | Yes      | sip, sccp, webrtc | Line protocol                                                                                                  |
+| `sip_username`  | string |          |                   | SIP username                                                                                                   |
+| `sip_secret`    | string |          |                   | SIP secret                                                                                                     |
 
 #### Incoming call
 
-| Field               | Type   | Required | Values | Description                                                                                                                                                 |
-| ------------------- | ------ | -------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| incall_exten        | string | Yes      |        | Number for calling the user from an incoming call (i.e outside of Wazo). The number must be inside the range of acceptable numbers defined for the context. |
-| incall_context      | string | Yes      |        | Context used for calls coming from outside of Wazo                                                                                                          |
-| incall_ring_seconds | int    |          |        | Number of seconds a call will ring before ending                                                                                                            |
+| Field                 | Type   | Required | Values | Description                                                                                                                                                 |
+| --------------------- | ------ | -------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `incall_exten`        | string | Yes      |        | Number for calling the user from an incoming call (i.e outside of Wazo). The number must be inside the range of acceptable numbers defined for the context. |
+| `incall_context`      | string | Yes      |        | Context used for calls coming from outside of Wazo                                                                                                          |
+| `incall_ring_seconds` | int    |          |        | Number of seconds a call will ring before ending                                                                                                            |
 
 #### Voicemail
 
-| Field                     | Type   | Required | Values | Description                                                |
-| ------------------------- | ------ | -------- | ------ | ---------------------------------------------------------- |
-| voicemail_name            | string | Yes      |        | Voicemail name                                             |
-| voicemail_number          | string | Yes      |        | Voicemail number                                           |
-| voicemail_context         | string | Yes      |        | Voicemail context                                          |
-| voicemail_password        | string |          |        | A sequence of Voicemail password digits or #               |
-| voicemail_email           | string |          |        | Email for sending notifications of new messages            |
-| voicemail_attach_audio    | bool   |          |        | Enable/Disable attaching audio files to email message      |
-| voicemail_delete_messages | bool   |          |        | Enable/Disable deleting message after notification is sent |
-| voicemail_ask_password    | bool   |          |        | Enable/Disable password checking                           |
+| Field                       | Type   | Required | Values | Description                                                |
+| --------------------------- | ------ | -------- | ------ | ---------------------------------------------------------- |
+| `voicemail_name`            | string | Yes      |        | Voicemail name                                             |
+| `voicemail_number`          | string | Yes      |        | Voicemail number                                           |
+| `voicemail_context`         | string | Yes      |        | Voicemail context                                          |
+| `voicemail_password`        | string |          |        | A sequence of Voicemail password digits or #               |
+| `voicemail_email`           | string |          |        | Email for sending notifications of new messages            |
+| `voicemail_attach_audio`    | bool   |          |        | Enable/Disable attaching audio files to email message      |
+| `voicemail_delete_messages` | bool   |          |        | Enable/Disable deleting message after notification is sent |
+| `voicemail_ask_password`    | bool   |          |        | Enable/Disable password checking                           |
 
 #### Call permissions
 
-| Field            | Type   | Required | Values                             | Description                                         |
-| ---------------- | ------ | -------- | ---------------------------------- | --------------------------------------------------- |
-| call_permissions | string |          | list separated by semicolons (`;`) | Names of the call permissions to assign to the user |
+| Field              | Type   | Required | Values                             | Description                                         |
+| ------------------ | ------ | -------- | ---------------------------------- | --------------------------------------------------- |
+| `call_permissions` | string |          | list separated by semicolons (`;`) | Names of the call permissions to assign to the user |
 
 ### Importing a file
 


### PR DESCRIPTION
Why:

* They appear in italic due to MD formatting