### PR TITLE
Added curl as Requirement

### DIFF
--- a/content/uc-doc/installation/install-system.md
+++ b/content/uc-doc/installation/install-system.md
@@ -15,7 +15,7 @@ To install the Unified Communication use case in an all-in-one setup, do the fol
 2. Run the following commands as root on the Debian system to provision sudo, git and Ansible:
 
    ```shell
-   apt-get install -yq sudo git ansible
+   apt-get install -yq sudo git ansible curl
    ```
 
 3. Extract the Wazo Platform installer


### PR DESCRIPTION
curl is not installed in the minimal installation of Debian, but required to follow the guide.