### PR TITLE
Add swarm-accessd spec

### DIFF
--- a/content/sections.yaml
+++ b/content/sections.yaml
@@ -1,5 +1,5 @@
 ---
-  - name: Programmable platform
+  - name: Programmable Platform
     slug: programmable-platform
     corporate: false
     modules:
@@ -203,7 +203,7 @@
         color: primary
         url: https://github.com/wazo-platform/wazo-sdk
 
-  - name: Internal platform
+  - name: Internal Platform
     slug: internal-platform
     modules:
       amid:


### PR DESCRIPTION
- Add `swarm-accessd` API spec on the corporate website
- Small rewording on descriptions

![Capture d’écran, le 2021-10-22 à 13 50 35](https://user-images.githubusercontent.com/1503758/138500568-15a8592a-ea80-41f0-8c84-b3d3cacf6168.jpg)
