### PR TITLE
WAZO-2576 backup/restore: remove cache files generated before restore

### DIFF
--- a/content/uc-doc/system/backup_restore.md
+++ b/content/uc-doc/system/backup_restore.md
@@ -205,6 +205,12 @@ sudo -u postgres dropdb asterisk
 sudo -u postgres pg_restore -C -d postgres asterisk-*.dump
 ```
 
+Remove the cache files generated from the previous database:
+
+```shell
+rm -rf /var/cache/wazo-confgend/*
+```
+
 Once the database and files have been restored, you can
 [finalize the restore](/uc-doc/system/backup_restore#after-restore)
 


### PR DESCRIPTION
Why:

* If not invalidated, wazo-confgend will still use the older cache files