### PR TITLE
specify version for invalid signature troubleshooting

### DIFF
--- a/content/uc-doc/upgrade/introduction.md
+++ b/content/uc-doc/upgrade/introduction.md
@@ -93,7 +93,7 @@ See our recommendation on
 
 ## Troubleshooting {#troubleshooting}
 
-### Invalid signature
+### Invalid signature (before 22.01 only)
 
 You may encounter the following error:
 


### PR DESCRIPTION
why: executing command after 22.01 will leave a not-updated key in the
default keyring
only wazo-keyring.gpg is updated