### PR TITLE
upgrade: fix wazo-dist command

### DIFF
--- a/content/uc-doc/upgrade/upgrade_specific_version/archives-from-wazo-buster.md
+++ b/content/uc-doc/upgrade/upgrade_specific_version/archives-from-wazo-buster.md
@@ -20,6 +20,6 @@ Procedures for upgrading to specific versions may freeze the version of your Waz
 commands to get the latest updates:
 
 ```shell
-wazo-dist pelican-buster
+wazo-dist -m pelican-buster
 wazo-upgrade
 ```


### PR DESCRIPTION
why: wazo-dist pelican-buster will set distribution on archive