### PR TITLE
use docker-compose from binary instead of python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-docker-compose


### PR DESCRIPTION
why: to have the latest docker-compose