### PR TITLE
fix react-markdown components

### DIFF
--- a/src/component/documentation/overview.js
+++ b/src/component/documentation/overview.js
@@ -8,23 +8,23 @@ import Layout from '../Layout';
 const flatten = (text, child) =>
   typeof child === 'string' ? text + child : React.Children.toArray(child.props.children).reduce(flatten, text);
 
-const getMenuRenderers = currentMenus => ({
-  heading: props => {
+const getMenuComponents = currentMenus => {
+  const BigHeading = props => {
     const text = props.children.reduce(flatten, '');
     const slug = text.toLowerCase().replace(/\W/g, '-');
     const active = slug in currentMenus;
 
-    if (props.level === 1) {
-      return null;
-    }
+    return (
+      <a className={`nav-link scrollto${active ? ' active' : ''}`} href={`#${slug}`}>
+        {props.children}
+      </a>
+    );
+  };
 
-    if (props.level === 2) {
-      return (
-        <a className={`nav-link scrollto${active ? ' active' : ''}`} href={`#${slug}`}>
-          {props.children}
-        </a>
-      );
-    }
+  const SmallHeading = props => {
+    const text = props.children.reduce(flatten, '');
+    const slug = text.toLowerCase().replace(/\W/g, '-');
+    const active = slug in currentMenus;
 
     return (
       <nav className="doc-sub-menu nav flex-column">
@@ -33,8 +33,17 @@ const getMenuRenderers = currentMenus => ({
         </a>
       </nav>
     );
-  },
-});
+  };
+
+  return {
+    h1: () => null,
+    h2: BigHeading,
+    h3: SmallHeading,
+    h4: SmallHeading,
+    h5: SmallHeading,
+    h6: SmallHeading,
+  };
+};
 
 const Section = props => {
   return (
@@ -45,25 +54,24 @@ const Section = props => {
 };
 const ViewportSection = handleViewport(Section);
 
-const getContentRenderers = (module, onEnter, onLeave) => ({
-  heading: props => {
+const getContentComponents = (module, onEnter, onLeave) => {
+  const BigHeading = props => {
     const text = props.children.reduce(flatten, '');
     const slug = text.toLowerCase().replace(/\W/g, '-');
 
-    if (props.level === 1) {
-      return null;
-    }
+    return (
+      <ViewportSection onEnterViewport={() => onEnter(slug)} onLeaveViewport={() => onLeave(slug)}>
+        <section className="doc-section" id={slug}>
+          <h2 className="section-title">{text}</h2>
+          <div className="section-block" />
+        </section>
+      </ViewportSection>
+    );
+  };
 
-    if (props.level === 2) {
-      return (
-        <ViewportSection onEnterViewport={() => onEnter(slug)} onLeaveViewport={() => onLeave(slug)}>
-          <section className="doc-section" id={slug}>
-            <h2 className="section-title">{text}</h2>
-            <div className="section-block" />
-          </section>
-        </ViewportSection>
-      );
-    }
+  const SmallHeading = props => {
+    const text = props.children.reduce(flatten, '');
+    const slug = text.toLowerCase().replace(/\W/g, '-');
 
     return (
       <ViewportSection onEnterViewport={() => onEnter(slug)} onLeaveViewport={() => onLeave(slug)}>
@@ -72,18 +80,27 @@ const getContentRenderers = (module, onEnter, onLeave) => ({
         </h3>
       </ViewportSection>
     );
-  },
-  image: props => (
-    <object
-      type="image/svg+xml"
-      data={`../../diagrams/${module.repository
-        .split('-')
-        .splice(1)
-        .join('-')}-${props.src}`}
-      aria-label={props.alt}
-    />
-  ),
-});
+  };
+
+  return {
+    h1: () => null,
+    h2: BigHeading,
+    h3: SmallHeading,
+    h4: SmallHeading,
+    h5: SmallHeading,
+    h6: SmallHeading,
+    img: props => (
+      <object
+        type="image/svg+xml"
+        data={`../../diagrams/${module.repository
+          .split('-')
+          .splice(1)
+          .join('-')}-${props.src}`}
+        aria-label={props.alt}
+      />
+    ),
+  };
+};
 
 const Page = ({ pageContext: { moduleName, module, overview } }) => {
   const [currentMenus, setCurrentMenu] = useState({});
@@ -111,7 +128,7 @@ const Page = ({ pageContext: { moduleName, module, overview } }) => {
                 <ReactMarkdown
                   moduleName={moduleName}
                   children={overview}
-                  components={getContentRenderers(module, onEnter, onLeave)}
+                  components={getContentComponents(module, onEnter, onLeave)}
                 />
               </div>
             </div>
@@ -122,7 +139,7 @@ const Page = ({ pageContext: { moduleName, module, overview } }) => {
                   <ReactMarkdown
                     allowedElements={['heading', 'text']}
                     children={overview}
-                    components={getMenuRenderers(currentMenus)}
+                    components={getMenuComponents(currentMenus)}
                   />
                 </nav>
               </div>


### PR DESCRIPTION
why: React-Markdown has been migrated from v4 to v8 and renderers
property has been replaced by components. Then this function must be
adapted to the new components concept