### PR TITLE
fix links issue when pathPrefix is used

### DIFF
--- a/src/component/LayoutCorporate.js
+++ b/src/component/LayoutCorporate.js
@@ -57,7 +57,7 @@ const PageHeader = () => (
       <div>
         <div className="branding">
           <h1 className="logo">
-            <Link to={withPrefix("/")}>
+            <Link to="/">
               <span className="text-bold">Documentation</span>
             </Link>
           </h1>
@@ -65,7 +65,7 @@ const PageHeader = () => (
 
         <ol className="breadcrumb">
           <li className="breadcrumb-item">
-            <Link to={withPrefix("/")}>Home</Link>
+            <Link to="/">Home</Link>
           </li>
           <li className="breadcrumb-item active">Quick Start</li>
         </ol>

--- a/src/component/LayoutCorporate.js
+++ b/src/component/LayoutCorporate.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Helmet from 'react-helmet';
 
-import { Link } from 'gatsby';
+import { Link, withPrefix } from 'gatsby';
 import Search from './corporate/search';
 
 const WazoHeader = () => {

--- a/src/component/LayoutCorporate.js
+++ b/src/component/LayoutCorporate.js
@@ -9,7 +9,7 @@ const WazoHeader = () => {
     <div className="wazo-header">
       <div className="container">
         <div className="site-logo">
-          <a href="/" title="Wazo" rel="home">
+          <a href={withPrefix("/")} title="Wazo" rel="home">
             <img className="header-image" alt="Wazo" src="https://i1.wp.com/wazo.io/wp-content/uploads/2020/03/WAZO-LogoWAZO-transparent-2.png?resize=300%2C79&ssl=1" title="Wazo" />
           </a>
         </div>
@@ -57,7 +57,7 @@ const PageHeader = () => (
       <div>
         <div className="branding">
           <h1 className="logo">
-            <Link to="/">
+            <Link to={withPrefix("/")}>
               <span className="text-bold">Documentation</span>
             </Link>
           </h1>
@@ -65,7 +65,7 @@ const PageHeader = () => (
 
         <ol className="breadcrumb">
           <li className="breadcrumb-item">
-            <Link to="/">Home</Link>
+            <Link to={withPrefix("/")}>Home</Link>
           </li>
           <li className="breadcrumb-item active">Quick Start</li>
         </ol>

--- a/src/component/LayoutPlatform.js
+++ b/src/component/LayoutPlatform.js
@@ -68,7 +68,7 @@ const Page = ({ children, section, className, pageTitle, pageTitleDate, PageTitl
 
       <header id="header" className="header">
         <div className="container">
-          <Link to={withPrefix("/")}>
+          <Link to="/">
             <img src={LogoHoriz} alt="Wazo Platform" id="wazo-platform-nav" />
           </Link>
           <nav id="main-nav" className={navigationClasses.join(' ')} role="navigation">
@@ -87,31 +87,31 @@ const Page = ({ children, section, className, pageTitle, pageTitleDate, PageTitl
                   </a>
                 </li>
                 <li className="nav-item">
-                  <Link className="nav-link" to={withPrefix("/documentation")} activeClassName="active" partiallyActive>
+                  <Link className="nav-link" to="/documentation" activeClassName="active" partiallyActive>
                     API
                   </Link>
                 </li>
                 <li className="nav-item">
-                  <Link className="nav-link" to={withPrefix("/use-cases")} activeClassName="active">
+                  <Link className="nav-link" to="/use-cases" activeClassName="active">
                     Use Cases
                   </Link>
                 </li>
                 <li className="nav-item">
-                  <Link className="nav-link" to={withPrefix("/blog")} activeClassName="active" partiallyActive>
+                  <Link className="nav-link" to="/blog" activeClassName="active" partiallyActive>
                     Blog
                   </Link>
                 </li>
                 <li className="nav-item">
-                  <Link className="nav-link" to={withPrefix("/tutorials")} activeClassName="active" partiallyActive>
+                  <Link className="nav-link" to="/tutorials" activeClassName="active" partiallyActive>
                     Tutorials
                   </Link>
                 </li>                <li className="nav-item">
-                                       <Link className="nav-link" to={withPrefix("/contribute")} activeClassName="active" partiallyActive>
+                                       <Link className="nav-link" to="/contribute" activeClassName="active" partiallyActive>
                     Contribute
                   </Link>
                 </li>
                 <li className="nav-item">
-                  <Link className="nav-link" to={withPrefix("/ecosystem")} activeClassName="active" partiallyActive>
+                  <Link className="nav-link" to="/ecosystem" activeClassName="active" partiallyActive>
                     Ecosystem
                   </Link>
                 </li>

--- a/src/component/LayoutPlatform.js
+++ b/src/component/LayoutPlatform.js
@@ -1,6 +1,6 @@
 import Helmet from 'react-helmet';
 import React, { useState, useEffect } from 'react';
-import { Link } from 'gatsby';
+import { Link, withPrefix } from 'gatsby';
 import Search from './platform/search';
 import LogoHoriz from '../assets/logo.horiz.svg';
 
@@ -56,7 +56,7 @@ const Page = ({ children, section, className, pageTitle, pageTitleDate, PageTitl
     <div className="main">
       <Helmet bodyAttributes={bodyAttributes}>
         <title>{headTitle.replace(/<\/?[^>]+(>|$)/g, '')}</title>
-        <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
+        <link rel="shortcut icon" type="image/x-icon" href={withPrefix("/favicon.ico")} />
         <meta property="og:image" content="https://wazo-platform.org/images/og-image.jpg" />
         <link
           href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800"
@@ -68,7 +68,7 @@ const Page = ({ children, section, className, pageTitle, pageTitleDate, PageTitl
 
       <header id="header" className="header">
         <div className="container">
-          <Link to="/">
+          <Link to={withPrefix("/")}>
             <img src={LogoHoriz} alt="Wazo Platform" id="wazo-platform-nav" />
           </Link>
           <nav id="main-nav" className={navigationClasses.join(' ')} role="navigation">
@@ -82,36 +82,36 @@ const Page = ({ children, section, className, pageTitle, pageTitleDate, PageTitl
             <div className="navbar-collapse collapse" id="navbar-collapse">
               <ul className="nav navbar-nav">
                 <li className="nav-item sr-only">
-                  <a className="nav-link scrollto" href="/#promo">
+                  <a className="nav-link scrollto" href={withPrefix("/#promo")}>
                     Home
                   </a>
                 </li>
                 <li className="nav-item">
-                  <Link className="nav-link" to="/documentation" activeClassName="active" partiallyActive>
+                  <Link className="nav-link" to={withPrefix("/documentation")} activeClassName="active" partiallyActive>
                     API
                   </Link>
                 </li>
                 <li className="nav-item">
-                  <Link className="nav-link" to="/use-cases" activeClassName="active">
+                  <Link className="nav-link" to={withPrefix("/use-cases")} activeClassName="active">
                     Use Cases
                   </Link>
                 </li>
                 <li className="nav-item">
-                  <Link className="nav-link" to="/blog" activeClassName="active" partiallyActive>
+                  <Link className="nav-link" to={withPrefix("/blog")} activeClassName="active" partiallyActive>
                     Blog
                   </Link>
                 </li>
                 <li className="nav-item">
-                  <Link className="nav-link" to="/tutorials" activeClassName="active" partiallyActive>
+                  <Link className="nav-link" to={withPrefix("/tutorials")} activeClassName="active" partiallyActive>
                     Tutorials
                   </Link>
                 </li>                <li className="nav-item">
-                  <Link className="nav-link" to="/contribute" activeClassName="active" partiallyActive>
+                                       <Link className="nav-link" to={withPrefix("/contribute")} activeClassName="active" partiallyActive>
                     Contribute
                   </Link>
                 </li>
                 <li className="nav-item">
-                  <Link className="nav-link" to="/ecosystem" activeClassName="active" partiallyActive>
+                  <Link className="nav-link" to={withPrefix("/ecosystem")} activeClassName="active" partiallyActive>
                     Ecosystem
                   </Link>
                 </li>

--- a/src/component/blog/article.js
+++ b/src/component/blog/article.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Layout from '../Layout';
 import ReactMarkdown from 'react-markdown';
-import { Link, withPrefix } from 'gatsby';
+import { Link } from 'gatsby';
 
 const Page = ({ pageContext: { title, author, tags: tagsRaw, date: dateRaw, category, body } }) => {
   const date = new Date(dateRaw);
@@ -15,10 +15,10 @@ const Page = ({ pageContext: { title, author, tags: tagsRaw, date: dateRaw, cate
           <ReactMarkdown children={body} />
 
           <div className="article--content--footer">
-            <Link className="article--content--footer-author" to={withPrefix("/blog")} state={{ filter: { type: 'author', value: author }}}>{author}</Link>
-            <p>Category: <Link to={withPrefix("/blog")} state={{ filter: { type: 'category', value: category }}}>{category}</Link></p>
+            <Link className="article--content--footer-author" to="/blog" state={{ filter: { type: 'author', value: author }}}>{author}</Link>
+            <p>Category: <Link to="/blog" state={{ filter: { type: 'category', value: category }}}>{category}</Link></p>
             {tags && tags.length && (
-              <p className="tags">Tags: {tags.map(item => <Link key={item} to={withPrefix("/blog")} state={{ filter: { type: 'tag', value: item }}}>{item}</Link>)}</p>
+              <p className="tags">Tags: {tags.map(item => <Link key={item} to="/blog" state={{ filter: { type: 'tag', value: item }}}>{item}</Link>)}</p>
             )}
           </div>
         </div>

--- a/src/component/blog/article.js
+++ b/src/component/blog/article.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Layout from '../Layout';
 import ReactMarkdown from 'react-markdown';
-import { Link } from 'gatsby';
+import { Link, withPrefix } from 'gatsby';
 
 const Page = ({ pageContext: { title, author, tags: tagsRaw, date: dateRaw, category, body } }) => {
   const date = new Date(dateRaw);
@@ -15,10 +15,10 @@ const Page = ({ pageContext: { title, author, tags: tagsRaw, date: dateRaw, cate
           <ReactMarkdown children={body} />
 
           <div className="article--content--footer">
-            <Link className="article--content--footer-author" to="/blog" state={{ filter: { type: 'author', value: author }}}>{author}</Link>
-            <p>Category: <Link to="/blog" state={{ filter: { type: 'category', value: category }}}>{category}</Link></p>
+            <Link className="article--content--footer-author" to={withPrefix("/blog")} state={{ filter: { type: 'author', value: author }}}>{author}</Link>
+            <p>Category: <Link to={withPrefix("/blog")} state={{ filter: { type: 'category', value: category }}}>{category}</Link></p>
             {tags && tags.length && (
-              <p className="tags">Tags: {tags.map(item => <Link key={item} to="/blog" state={{ filter: { type: 'tag', value: item }}}>{item}</Link>)}</p>
+              <p className="tags">Tags: {tags.map(item => <Link key={item} to={withPrefix("/blog")} state={{ filter: { type: 'tag', value: item }}}>{item}</Link>)}</p>
             )}
           </div>
         </div>

--- a/src/component/blog/index.js
+++ b/src/component/blog/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Layout from '../Layout';
-import { Link } from 'gatsby';
+import { Link, withPrefix } from 'gatsby';
 
 const sortArticles = a => a.sort((a, b) => {
   const dateA = new Date(a.date);
@@ -11,8 +11,8 @@ const sortArticles = a => a.sort((a, b) => {
 });
 
 const Page = ({ location, pageContext: { articles: articlesRaw  } }) => {
-  const [ filter, setFilter ] = useState((location.state && location.state.filter) || {}); 
-  const [ articles, setArticles ] = useState(articlesRaw); 
+  const [ filter, setFilter ] = useState((location.state && location.state.filter) || {});
+  const [ articles, setArticles ] = useState(articlesRaw);
 
   // sort articles
   sortArticles(articles);
@@ -49,22 +49,21 @@ const Page = ({ location, pageContext: { articles: articlesRaw  } }) => {
             const date = new Date(dateRaw);
             const formattedDate = `${date.getDate()} ${date.toLocaleString('default', { month: 'long' })} ${date.getFullYear()}`;
             const tags = tagsRaw && tagsRaw.split(',');
- 
+
             return <div key={slug} className="item">
-              <Link to={`/blog/${slug}`} className="title">{title}</Link>
+              <Link to={withPrefix(`/blog/${slug}`)} className="title">{title}</Link>
               <div className="summary">{summary}...</div>
               <div className="head">
                 Posted on {formattedDate}  {" "}
-                in <Link className="hilite" to="/blog" state={{ filter: { type: 'category', value: category }}}>{category}</Link> {" "}
-                by <Link className="hilite" to="/blog" state={{ filter: { type: 'author', value: author }}}>{author}</Link>  {" "}
+                in <Link className="hilite" to={withPrefix("/blog")} state={{ filter: { type: 'category', value: category }}}>{category}</Link> {" "}
+                by <Link className="hilite" to={withPrefix("/blog")} state={{ filter: { type: 'author', value: author }}}>{author}</Link>  {" "}
                 {tags && tags.length &&
-                  <span className="tags"> * Tagged with {tags.map(item => <Link key={item} className="hilite" to="/blog" state={{ filter: { type: 'tag', value: item }}}>{item}</Link>)}</span>}
-              </div> 
-            </div>; 
+                 <span className="tags"> * Tagged with {tags.map(item => <Link key={item} className="hilite" to={withPrefix("/blog")} state={{ filter: { type: 'tag', value: item }}}>{item}</Link>)}</span>}
+              </div>
+            </div>;
           })}
         </div>
       </div>
-      
     </Layout>
   );
 }

--- a/src/component/blog/index.js
+++ b/src/component/blog/index.js
@@ -51,14 +51,14 @@ const Page = ({ location, pageContext: { articles: articlesRaw  } }) => {
             const tags = tagsRaw && tagsRaw.split(',');
 
             return <div key={slug} className="item">
-              <Link to={withPrefix(`/blog/${slug}`)} className="title">{title}</Link>
+              <Link to={`/blog/${slug}`} className="title">{title}</Link>
               <div className="summary">{summary}...</div>
               <div className="head">
                 Posted on {formattedDate}  {" "}
-                in <Link className="hilite" to={withPrefix("/blog")} state={{ filter: { type: 'category', value: category }}}>{category}</Link> {" "}
-                by <Link className="hilite" to={withPrefix("/blog")} state={{ filter: { type: 'author', value: author }}}>{author}</Link>  {" "}
+                in <Link className="hilite" to="/blog" state={{ filter: { type: 'category', value: category }}}>{category}</Link> {" "}
+                by <Link className="hilite" to="/blog" state={{ filter: { type: 'author', value: author }}}>{author}</Link>  {" "}
                 {tags && tags.length &&
-                 <span className="tags"> * Tagged with {tags.map(item => <Link key={item} className="hilite" to={withPrefix("/blog")} state={{ filter: { type: 'tag', value: item }}}>{item}</Link>)}</span>}
+                 <span className="tags"> * Tagged with {tags.map(item => <Link key={item} className="hilite" to="/blog" state={{ filter: { type: 'tag', value: item }}}>{item}</Link>)}</span>}
               </div>
             </div>;
           })}

--- a/src/component/provisioning/components/Vendors.js
+++ b/src/component/provisioning/components/Vendors.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { withPrefix } from "gatsby"
 
 import { buildTable } from '../helpers';
 const slugify = require('../../../builder/slugify');
@@ -19,17 +20,17 @@ const Page = ({ plugins, images }) => {
 
   return Object.keys(plugins).map(vendor => (
       <div className="vendor" key={vendor}>
-        <a className="title" href={`/provisioning/${slugify(vendor)}`} id={vendor} onClick={onVendorClick}>{vendor}</a>
+        <a className="title" href={withPrefix(`/provisioning/${slugify(vendor)}`)} id={vendor} onClick={onVendorClick}>{vendor}</a>
         {vendor === currentVendor && 
           <div className="phones">
             {Object.keys(plugins[vendor]).sort().map(name => {
               const id = `${slugify(vendor)}-${slugify(name)}`;
               return <div className={id === currentDevice ? 'selected' : ''} key={id} >
-                <a href={`/provisioning/${slugify(vendor)}/${slugify(name)}`} onClick={onDeviceClick} id={id}>{name}</a>
+                <a href={withPrefix(`/provisioning/${slugify(vendor)}/${slugify(name)}`)} onClick={onDeviceClick} id={id}>{name}</a>
                 {id === currentDevice && <div className="slide">
                   <div className="image">
                     <div className="name">{name}</div>
-                    {images[slugify(vendor)] && images[slugify(vendor)].indexOf(`${slugify(name)}.png`) !== -1 ? <img src={`/provisioning/${slugify(vendor)}-${slugify(name)}.png`} alt={`${slugify(vendor)}-${name}`}/> : <img src='/provisioning/img-placeholder.png' alt={`${slugify(vendor)}-${name}`} />}
+                    {images[slugify(vendor)] && images[slugify(vendor)].indexOf(`${slugify(name)}.png`) !== -1 ? <img src={withPrefix(`/provisioning/${slugify(vendor)}-${slugify(name)}.png`)} alt={`${slugify(vendor)}-${name}`}/> : <img src={withPrefix('/provisioning/img-placeholder.png')} alt={`${slugify(vendor)}-${name}`} />}
                   </div>
                   <div className="content">{buildTable(plugins[vendor][name])}</div>
             </div>}

--- a/src/component/provisioning/phone.js
+++ b/src/component/provisioning/phone.js
@@ -3,6 +3,8 @@ import React  from 'react';
 import Layout from '../Layout';
 import { buildTable } from './helpers';
 import './provisioning.scss';
+import { withPrefix } from 'gatsby';
+
 const slugify = require('../../builder/slugify');
 
 const vendorsUrl = '/uc-doc/ecosystem/supported_devices';
@@ -15,14 +17,14 @@ const Page = ({ pageContext: { name, vendor, phone, vendor_images } }) => {
   ];
 
   return (
-    <Layout pageTitle={`<a href="${vendorsUrl}">Provd Plugins</a> &gt; <a href="/provisioning/${slugify(vendor)}">${vendor}</a> &gt; ${name}`} breadcrumbs={breadcrumbs} currentPageName={name}>
+    <Layout pageTitle={`<a href="${vendorsUrl}">Provd Plugins</a> &gt; <a href=withPrefix("/provisioning/${slugify(vendor)}")>${vendor}</a> &gt; ${name}`} breadcrumbs={breadcrumbs} currentPageName={name}>
       <div className="doc-wrapper provisioning-phone">
         <div className="container">
           <div className="row">
             <div className="col-card col col-3">
               <div className="card">
                 <div className="body">
-                  {vendor_images && vendor_images.indexOf(`${slugify(name)}.png`) !== -1 ? <img src={`/provisioning/${slugify(vendor)}-${slugify(name)}.png`} alt={`${slugify(vendor)}-${name}`}/> : <img src='/provisioning/img-placeholder.png' alt={`${slugify(vendor)}-${name}`} />}
+                  {vendor_images && vendor_images.indexOf(`${slugify(name)}.png`) !== -1 ? <img src={withPrefix(`/provisioning/${slugify(vendor)}-${slugify(name)}.png`)} alt={`${slugify(vendor)}-${name}`}/> : <img src={withPrefix('/provisioning/img-placeholder.png')} alt={`${slugify(vendor)}-${name}`} />}
                 </div>
               </div>
             </div>

--- a/src/component/provisioning/phone.js
+++ b/src/component/provisioning/phone.js
@@ -1,23 +1,23 @@
 import React  from 'react';
+import { withPrefix } from "gatsby"
 
 import Layout from '../Layout';
 import { buildTable } from './helpers';
 import './provisioning.scss';
-import { withPrefix } from 'gatsby';
 
 const slugify = require('../../builder/slugify');
 
-const vendorsUrl = '/uc-doc/ecosystem/supported_devices';
+const vendorsUrl = withPrefix('/uc-doc/ecosystem/supported_devices');
 
 
 const Page = ({ pageContext: { name, vendor, phone, vendor_images } }) => {
   const breadcrumbs = [
     { url: vendorsUrl, label: 'Provd plugins' },
-    { url: `/provisioning/${slugify(vendor)}`, label: vendor },
+    { url: withPrefix(`/provisioning/${slugify(vendor)}`), label: vendor },
   ];
 
   return (
-    <Layout pageTitle={`<a href="${vendorsUrl}">Provd Plugins</a> &gt; <a href=withPrefix("/provisioning/${slugify(vendor)}")>${vendor}</a> &gt; ${name}`} breadcrumbs={breadcrumbs} currentPageName={name}>
+    <Layout pageTitle={`<a href="${vendorsUrl}">Provd Plugins</a> &gt; <a href="${withPrefix(`/provisioning/${slugify(vendor)}`)}">${vendor}</a> &gt; ${name}`} breadcrumbs={breadcrumbs} currentPageName={name}>
       <div className="doc-wrapper provisioning-phone">
         <div className="container">
           <div className="row">

--- a/src/component/provisioning/vendor.js
+++ b/src/component/provisioning/vendor.js
@@ -1,10 +1,11 @@
 import React  from 'react';
+import { withPrefix } from "gatsby"
 
 import Layout from '../Layout';
 import './provisioning.scss';
 const slugify = require('../../builder/slugify');
 
-const vendorsUrl = '/uc-doc/ecosystem/supported_devices';
+const vendorsUrl = withPrefix('/uc-doc/ecosystem/supported_devices');
 
 const breadcrumbs = [{
   url: vendorsUrl, label: 'Provd plugins',
@@ -19,12 +20,12 @@ const Page = ({ pageContext: { name, vendor_plugins, vendor_images } }) => (
             {Object.keys(vendor_plugins).map(phoneName => (
               <div className="col-md-4 col-12 mb-3" key={phoneName}>
                 <div className="card">
-                  <a className="card-header" href={`/provisioning/${slugify(name)}/${slugify(phoneName)}`}>{phoneName}</a>
+                  <a className="card-header" href={withPrefix(`/provisioning/${slugify(name)}/${slugify(phoneName)}`)}>{phoneName}</a>
                    <div className="body">
-                      <a className="phone-picture" href={`/provisioning/${slugify(name)}/${slugify(phoneName)}`}>
+                      <a className="phone-picture" href={withPrefix(`/provisioning/${slugify(name)}/${slugify(phoneName)}`)}>
                         {vendor_images && vendor_images.indexOf(`${slugify(phoneName)}.png`) !== -1 
-                          ? <img src={`/provisioning/${slugify(name)}-${slugify(phoneName)}.png`} alt={phoneName} />
-                          : <img src={`/provisioning/img-placeholder.png`} alt={phoneName} />}
+                          ? <img src={withPrefix(`/provisioning/${slugify(name)}-${slugify(phoneName)}.png`)} alt={phoneName} />
+                          : <img src={withPrefix(`/provisioning/img-placeholder.png`)} alt={phoneName} />}
                       </a>
                   </div>
                 </div>

--- a/src/component/tutorials/index.js
+++ b/src/component/tutorials/index.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import Layout from '../Layout';
-import { Link } from 'gatsby';
+import { Link, withPrefix } from 'gatsby';
 
 const sortTutorials = (a) =>
   a.sort((a, b) => {
@@ -19,8 +19,8 @@ const Page = ({ pageContext: { tutorials: tutorialsRaw } }) => {
       <div className="container">
         <div className="tutorials-items">
           {tutorials.map(({ title, slug, author, summary, thumbnail }) => (
-            <Link key={slug} to={`/tutorials/${slug}`} className="tutorials-items-item">
-              <div class="thumbnail" style={{ backgroundImage: `url(/images/tutorials/${thumbnail})` }} />
+            <Link key={slug} to={withPrefix(`/tutorials/${slug}`)} className="tutorials-items-item">
+              <div class="thumbnail" style={{ backgroundImage: `url(${withPrefix('/images/tutorials/${thumbnail')}})` }} />
 
               <h2 className="title">{title}</h2>
               <p className="summary">{summary}...</p>

--- a/src/component/tutorials/index.js
+++ b/src/component/tutorials/index.js
@@ -19,7 +19,7 @@ const Page = ({ pageContext: { tutorials: tutorialsRaw } }) => {
       <div className="container">
         <div className="tutorials-items">
           {tutorials.map(({ title, slug, author, summary, thumbnail }) => (
-            <Link key={slug} to={withPrefix(`/tutorials/${slug}`)} className="tutorials-items-item">
+            <Link key={slug} to={`/tutorials/${slug}`} className="tutorials-items-item">
               <div class="thumbnail" style={{ backgroundImage: `url(${withPrefix('/images/tutorials/${thumbnail')}})` }} />
 
               <h2 className="title">{title}</h2>

--- a/src/component/uc-doc/TableOfContents.js
+++ b/src/component/uc-doc/TableOfContents.js
@@ -126,7 +126,7 @@ const Page = () => {
   const renderLinks = () => {
     return (
       <ul>
-        <li><Link to={withPrefix("/uc-doc/")}>Wazo Documentation</Link></li>
+        <li><Link to="/uc-doc/">Wazo Documentation</Link></li>
         { renderLinksRecurse(links['introduction']) }
         { renderLinksRecurse(links['installation']) }
         { renderLinksRecurse(links['upgrade']) }

--- a/src/component/uc-doc/TableOfContents.js
+++ b/src/component/uc-doc/TableOfContents.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Link } from "gatsby"
+import { Link, withPrefix } from "gatsby"
 
 import { tableOfContentLinksOrdering } from './utils'
 
@@ -42,7 +42,7 @@ const Page = () => {
   let undefinedKeyIndex = 0;
 
   useEffect(() => {
-    fetch('/json/uc-doc-submenu.json', {
+    fetch(withPrefix('/json/uc-doc-submenu.json'), {
       method: 'GET',
       headers: {}
     }).then(response => response.json()).then(data => {

--- a/src/component/uc-doc/TableOfContents.js
+++ b/src/component/uc-doc/TableOfContents.js
@@ -126,7 +126,7 @@ const Page = () => {
   const renderLinks = () => {
     return (
       <ul>
-        <li><Link to="/uc-doc/">Wazo Documentation</Link></li>
+        <li><Link to={withPrefix("/uc-doc/")}>Wazo Documentation</Link></li>
         { renderLinksRecurse(links['introduction']) }
         { renderLinksRecurse(links['installation']) }
         { renderLinksRecurse(links['upgrade']) }

--- a/src/html.js
+++ b/src/html.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react"
 import PropTypes from "prop-types"
+import { withPrefix } from "gatsby"
 import { corporate } from '../config-wazo';
 
 export default function HTML(props) {
@@ -18,7 +19,7 @@ export default function HTML(props) {
         />
         {props.headComponents}
         <script type="text/javascript" src="https://code.jquery.com/jquery-3.2.1.min.js" />
-        <script type="text/javascript" src="/js/prism.js" />
+        <script type="text/javascript" src={withPrefix("/js/prism.js")} />
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossOrigin="anonymous"></script>
         <script
           type="text/javascript"
@@ -26,7 +27,7 @@ export default function HTML(props) {
         />
         <script async src="https://www.googletagmanager.com/gtag/js?id=UA-56722061-8"></script>
         <meta name="google-site-verification" content="VfXUU25hamqC0zHjgxvyVDPk8CqGiWjLSRFE8BZ1mmE" />
-        <script type="text/javascript" src="/js/main.js" defer />
+        <script type="text/javascript" src={withPrefix("/js/main.js")} defer />
       </head>
       <body {...props.bodyAttributes}>
         {props.preBodyComponents}


### PR DESCRIPTION
why: pathPrefix option is used by zuul
To test with prefix
```diff
diff --git a/docker-compose-tests.yml b/docker-compose-tests.yml
index f968be7..b4bafa2 100644
--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -7,7 +7,7 @@ services:
       - ./public:/app/public:ro
     expose:
       - "8000"
-    command: bash -c "cd /app/public && python -m http.server 8000"
+    command: bash -c "cd /app && python -m http.server 8000"
   # Allow to run scrap tests before deployment
   test:
     build: tests
diff --git a/gatsby-config.js b/gatsby-config.js
index 6a3c341..0456e66 100644
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,6 +7,7 @@ const path = require('path');
  */
 
 module.exports = {
+  pathPrefix: '/public',
   plugins: [
     'gatsby-plugin-react-helmet',
     {
```