### PR TITLE
zuul: increase ram for periodic job

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -124,4 +124,4 @@
     periodic:
       jobs:
         - yarn-build-test:
-            nodeset: vm-debian-10-m1s
+            nodeset: vm-debian-10-m1m


### PR DESCRIPTION
Why:

* The tests are failing on random URLs, making the whole job fail
everyday