### PR TITLE
increase vm size to have 4GB RAM instead of 2G

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -107,20 +107,20 @@
     check:
       jobs:
         - yarn-build-copy:
-            nodeset: vm-debian-10-m2s
+            nodeset: vm-debian-10-m1m
         - yarn-prettier-uc-doc:
             nodeset: vm-debian-10-m1s
     gate:
       jobs:
         - yarn-build-search-copy:
-            nodeset: vm-debian-10-m1s
+            nodeset: vm-debian-10-m1m
     auto-merge:
       jobs:
         - noop
     post:
       jobs:
         - yarn-build-publish:
-            nodeset: vm-debian-10-m1s
+            nodeset: vm-debian-10-m1m
     periodic:
       jobs:
         - yarn-build-test:


### PR DESCRIPTION
why: latest development and dependencies and version need more RAM and
reach 2G to easily

Fix issue during build for https://github.com/wazo-platform/wazo-platform.org/pull/511