### PR TITLE
Syntax highlight articles & tutorials

### DIFF
--- a/content/blog/asterisk-scale-apps-introduction.md
+++ b/content/blog/asterisk-scale-apps-introduction.md
@@ -1,10 +1,12 @@
-Title: Scaling Asterisk applications
-Date: 2020-01-13 14:00:00
-Author: Sylvain Baubeau and Sylvain Afchain
-Category: Wazo Platform
-Tags: Asterisk, Applications, Stasis, Scalability
-Slug: scale-asterisk-apps
-Status: published
+---
+title: Scaling Asterisk applications
+date: 2020-01-13 14:00:00
+author: Sylvain Baubeau and Sylvain Afchain
+category: Wazo Platform
+tags: Asterisk, Applications, Stasis, Scalability
+slug: scale-asterisk-apps
+status: published
+---
 
 # Scaling Asterisk applications
 

--- a/content/blog/creating-cross-platform-push-to-talk-app.md
+++ b/content/blog/creating-cross-platform-push-to-talk-app.md
@@ -1,10 +1,12 @@
-Title: Creating a Cross Environment push-to-talk Application Using Wazo
-Date: 2021-10-12 12:30:00
-Author: Emmanuel QUENTIN
-Category: Hackathon
-Tags: VOIP, WebRTC, push-to-talk, react, expo
-Slug: creating-cross-platform-push-to-talk-app
-Status: published
+---
+title: Creating a Cross Environment push-to-talk Application Using Wazo
+date: 2021-10-12 12:30:00
+author: Emmanuel QUENTIN
+category: Hackathon
+tags: VOIP, WebRTC, push-to-talk, react, expo
+slug: creating-cross-platform-push-to-talk-app
+status: published
+---
 
 ## Creating a Cross Environment push-to-talk Application Using Wazo
 
@@ -125,7 +127,7 @@ We're using and improving our [Javascript SDK](https://github.com/wazo-platform/
 // Setting the wazo's server
 Wazo.Auth.setHost('wazo.my-company.com');
 
-// Authenticating the user 
+// Authenticating the user
 const session = await Wazo.Auth.logIn(username, password);
 
 // Joining a conference

--- a/content/blog/engine-installation-and-acceptance-tests.md
+++ b/content/blog/engine-installation-and-acceptance-tests.md
@@ -1,10 +1,12 @@
-Title: Development environment for Wazo Platform and acceptance tests
-Date: 2019-11-20
-Author: Mehdi Abaakouk
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: engine-installation-acceptance-tests
-Status: published
+---
+title: Development environment for Wazo Platform and acceptance tests
+date: 2019-11-20
+author: Mehdi Abaakouk
+category: Wazo Platform
+tags: wazo-platform, development
+slug: engine-installation-acceptance-tests
+status: published
+---
 
 
 # Run acceptance tests on freshly installed virtual machine

--- a/content/blog/events-documentation.md
+++ b/content/blog/events-documentation.md
@@ -1,15 +1,17 @@
-Title: New Events Documentation
-Date: 2022-10-22 13:00:00
-Author: Julien Alie
-Category: Wazo Platform
-Tags: Applications, Documentation
-Slug: new-events-documentation
-Status: published
+---
+title: New Events Documentation
+date: 2022-10-22 13:00:00
+author: Julien Alie
+category: Wazo Platform
+tags: Applications, Documentation
+slug: new-events-documentation
+status: published
+---
 
-Hello Wazo community!  
+Hello Wazo community!
 
-In line with launching our new [event documentation](https://wazo-platform.org/documentation) section on our website, in the last few months, 
-we have been busy refactoring our events subsystem in Wazo to make it simpler for developers and ourselves.  
+In line with launching our new [event documentation](https://wazo-platform.org/documentation) section on our website, in the last few months,
+we have been busy refactoring our events subsystem in Wazo to make it simpler for developers and ourselves.
 
 The first and most important change is that events are now fully _tenant-aware_, meaning they will never be dispatched to users outside
 of its intended tenant.
@@ -24,8 +26,8 @@ Meant to be consumed by all connected users of a tenant.
 These events usually represent changes at the tenant level on the stack (i.e: configuration setting changed)
 
 - **User-Level Events:**
-Meant to be consumed by individual users.  
-These events usually represent specific actions targeting a user (i.e: joining a meeting or a conference, 
+Meant to be consumed by individual users.
+These events usually represent specific actions targeting a user (i.e: joining a meeting or a conference,
 receiving a chat message, receiving a call, etc)
 
 
@@ -33,7 +35,7 @@ At a more technical level, here's how we implement it within Wazo:
 
 For an event to be forwarded to a user connected through the websocket, the event must meet the following criteria:
 - Headers must have an entry `tenant_uuid` = `<tenant uuid>`
-- Headers must have an entry `user_uuid:<user uuid>` = `true` (or `user_uuid:*` = `true` for all users) 
+- Headers must have an entry `user_uuid:<user uuid>` = `true` (or `user_uuid:*` = `true` for all users)
 
 Any event will always be available to services, but to be relayed to users, these entries are mandatory.
 
@@ -65,8 +67,8 @@ A few things to note here are the required properties when writing new events:
 * _name_: name of the event, used for routing the message
 * _routing_key_fmt_: routing key used to route messages in a topic exchange (compatibility with older version)
 
-Now, when we publish this event using our publisher, headers will be generated automatically. 
-In our example, because our event is derived from `UserEvent`, the headers will be (using example values): 
+Now, when we publish this event using our publisher, headers will be generated automatically.
+In our example, because our event is derived from `UserEvent`, the headers will be (using example values):
 ```py
 {
 	'name': 'do_something',
@@ -79,14 +81,14 @@ In our example, because our event is derived from `UserEvent`, the headers will 
 
 ## What if I need **all** events?
 
-In the old system, it was possible for a user to have access to all events (as long as it had the correct permissions).  
+In the old system, it was possible for a user to have access to all events (as long as it had the correct permissions).
 But what if I still need that behavior, e.g in a m2m (machine to machine) forwarding/dispatching scenario?
 
 Well, we have you covered!
 
-If a user belongs to the stack's _master tenant_ (in opposition to a regular tenant), from the bus perspective, that user 
+If a user belongs to the stack's _master tenant_ (in opposition to a regular tenant), from the bus perspective, that user
 is considered an admin and will be able to receive all events it is registered to, independently of headers.
- 
+
 
 ## TLDR
 

--- a/content/blog/extending-wazo-with-plugind.md
+++ b/content/blog/extending-wazo-with-plugind.md
@@ -1,9 +1,11 @@
-Title: Extending Wazo with Plugins
-Date: 2017-06-26
-Author: Pascal Cadotte Michaud
-Category: Wazo
-Slug: extending-wazo-plugins-en
-Status: published
+---
+title: Extending Wazo with Plugins
+date: 2017-06-26
+author: Pascal Cadotte Michaud
+category: Wazo
+slug: extending-wazo-plugins-en
+status: published
+---
 
 
 One of the strengths of Wazo is that the administrator can modify the system to add new features or override default behaviors that are not appropriate to its use case. There are many ways to extend Wazo.

--- a/content/blog/have-an-itch.md
+++ b/content/blog/have-an-itch.md
@@ -1,10 +1,12 @@
-Title: Have an itch with your communication system?
-Date: 2017-02-01
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo
-Slug: itch-communication-system
-Status: published
+---
+title: Have an itch with your communication system?
+date: 2017-02-01
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo
+slug: itch-communication-system
+status: published
+---
 
 *French/Français: Une version française plus bas*
 

--- a/content/blog/how-to-make-your-voip-application-always-reachable.md
+++ b/content/blog/how-to-make-your-voip-application-always-reachable.md
@@ -1,10 +1,12 @@
-Title: How to Make your VoIP Application Always Reachable
-Date: 2019-03-19 12:30:00
-Author: Emmanuel QUENTIN
-Category: Wazo IPBX
-Tags: Mobile, notification, VoIP, CallKit, ConnectionService, PushKit
-Slug: how-to-make-your-voip-application-always-reachable
-Status: published
+---
+title: How to Make your VoIP Application Always Reachable
+date: 2019-03-19 12:30:00
+author: Emmanuel QUENTIN
+category: Wazo IPBX
+tags: Mobile, notification, VoIP, CallKit, ConnectionService, PushKit
+slug: how-to-make-your-voip-application-always-reachable
+status: published
+---
 
 ![call-keep](https://user-images.githubusercontent.com/2076632/54532019-213ddf80-495d-11e9-85ee-7d2aa38a3fe9.gif)
 
@@ -31,13 +33,13 @@ At Wazo we use React Native to build our mobile application, the community of de
 
 A thing I love with Wazo, it's the commitment to its values around FOSS. We use open source everyday and contribute to it. We've [open sourced](https://github.com/wazo-platform/) everything since the beginning of our journey. When we saw the opportunity of developing a software that the community can benefit we've opened our IDE and start coding.
 
-Developing a react-native module in Java is very easy, even if Java was not our preferred language, and after 3 days we ended with a working module that integrates all features of ConnectionService. 
+Developing a react-native module in Java is very easy, even if Java was not our preferred language, and after 3 days we ended with a working module that integrates all features of ConnectionService.
 
 ![ConnectionService](https://user-images.githubusercontent.com/2076632/54477272-c7161080-47dc-11e9-939e-f6d1faa49840.png)
 
 ## Improve the Developer Experience
 
-So we now have 2 libraries dealing with the same goal: displaying incall system UI. But why should we install, setup and abstract 2 libraries with the same point ? 
+So we now have 2 libraries dealing with the same goal: displaying incall system UI. But why should we install, setup and abstract 2 libraries with the same point ?
 `react-native-callkit` uses the name of the iOS Framework, it would be misunderstood if we integrate the Android feature in it. So we've decided to fork it and create a new [`react-native-callkeep`](https://github.com/react-native-webrtc/react-native-callkeep) repository with both Android and iOS implementation.
 
 With it, we can seamlessly notify both Android and iOS users of an incoming call, and even using Wazo to make calls from the native Phone application:

--- a/content/blog/introducing-wazo.md
+++ b/content/blog/introducing-wazo.md
@@ -1,9 +1,11 @@
-Title: Introducing Wazo
-Date: 2016-12-05 13:00
-Author: The Wazo Authors
-Category: Wazo software
-Slug: introducing-wazo
-Status: published
+---
+title: Introducing Wazo
+date: 2016-12-05 13:00
+author: The Wazo Authors
+category: Wazo software
+slug: introducing-wazo
+status: published
+---
 
 
 *French/Français: La [version française](#french) suit la version anglaise.*

--- a/content/blog/introducing-wazotester.md
+++ b/content/blog/introducing-wazotester.md
@@ -1,10 +1,12 @@
-Title: wazo-tester - an introduction to our SIP testing tool
-Date: 2019-10-29
-Author: Aleksandar Sosic
-Category: Wazo Platform C4
-Tags: wazo-platform, c4, kamailio, sip, test
-Slug: wazo-tester-introduction
-Status: published
+---
+title: wazo-tester - an introduction to our SIP testing tool
+date: 2019-10-29
+author: Aleksandar Sosic
+category: Wazo Platform C4
+tags: wazo-platform, c4, kamailio, sip, test
+slug: wazo-tester-introduction
+status: published
+---
 
 # wazo-tester - an introduction to our SIP testing tool
 
@@ -117,7 +119,7 @@ teardown:
   - type: api
     method: DELETE
     uri: "/tenants/{tenant.id}"
-    
+
 workers:
   - scenario: "test_did_ok.xml"
     number: 1
@@ -138,7 +140,7 @@ As you can observe we launch a bunch of API calls to define a `tenant`, a `domai
 
 The `worker` part uses a sipp scenario and calls a user on this number `39040123456` which will match our did rule and with our Kamailio C4 routing will route the call to our ipbx. The `ipbx` will then respond with a predefined scenario and make the sipp test pass.
 
-The `scenario` file is a template sipp XML file which we parse with python and substitute the `values` defined in the `workers` part of our YAML. 
+The `scenario` file is a template sipp XML file which we parse with python and substitute the `values` defined in the `workers` part of our YAML.
 
 For example, the `%(to_user)s` in our XML example is changed into `39040123456` and only then sipp is run with the generated XML file.
 
@@ -153,7 +155,7 @@ Or from our repository [wazo-tester](https://github.com/wazo-platform/wazo-teste
 
 
 ## Preparing a testing environment
-  
+
 The best way to try wazotester is with the Wazo C4 is to run Wazo C4 from our repository `https://github.com/wazo-platform/wazo-kamailio-config` using `Docker` with `docker-compose` which runs different containers defined in the `docker-compose.yaml` file.
 
 
@@ -164,7 +166,7 @@ Options:
   -t, --target TEXT      IP address of the SIP server to use as target
   -e, --executable TEXT  Command to exec for running sipp
   -d, --directory PATH   Working directory, if not specified a temporary
-                         directory is created. 
+                         directory is created.
   -s, --seed INTEGER     Initialize the Python random machine with this seed
                          value.
   -a, --apiurl TEXT      [default: http://router-confd:8000]

--- a/content/blog/kamailio-consul-service-discovery.md
+++ b/content/blog/kamailio-consul-service-discovery.md
@@ -1,10 +1,12 @@
-Title: Kamailio service discovery with Consul
-Date: 2019-12-02
-Author: Fabio Tranchitella
-Category: Wazo Platform C4
-Tags: wazo-platform, c4, consul, kubernetes, cloud, kamailio, sip
-Slug: kamailio-consul-service-discovery
-Status: published
+---
+title: Kamailio service discovery with Consul
+date: 2019-12-02
+author: Fabio Tranchitella
+category: Wazo Platform C4
+tags: wazo-platform, c4, consul, kubernetes, cloud, kamailio, sip
+slug: kamailio-consul-service-discovery
+status: published
+---
 
 # Using Consul for service discovery in Wazo Platform C4
 

--- a/content/blog/kamailio-developpers-meeting-2019-kemi.md
+++ b/content/blog/kamailio-developpers-meeting-2019-kemi.md
@@ -1,10 +1,12 @@
-Title: Kamailio developpers meeting 2019 - kemi framework
-Date: 2019-12-06
-Author: Mathias WOLFF
-Category: kamailio
-Tags: wazo-platform, development, kamailio, KEMI
-Slug: kamailio-developpers-meeting-2019-kemi
-Status: published
+---
+title: Kamailio developpers meeting 2019 - kemi framework
+date: 2019-12-06
+author: Mathias WOLFF
+category: kamailio
+tags: wazo-platform, development, kamailio, KEMI
+slug: kamailio-developpers-meeting-2019-kemi
+status: published
+---
 
 ![kamailio developpers event 2019](/images/blog/kamailio-dev-meeting-2019/kamailio_dev_event_2019.jpeg)
 

--- a/content/blog/kamailio-ha-dispatcher-and-dmq.md
+++ b/content/blog/kamailio-ha-dispatcher-and-dmq.md
@@ -1,5 +1,5 @@
 ---
-title: Kamailio HA: dispatcher and dmq modules
+title: "Kamailio HA: dispatcher and dmq modules"
 date: 2019-11-15
 author: Fabio Tranchitella
 category: Wazo Platform C4

--- a/content/blog/kamailio-ha-dispatcher-and-dmq.md
+++ b/content/blog/kamailio-ha-dispatcher-and-dmq.md
@@ -1,10 +1,12 @@
-Title: Kamailio HA: dispatcher and dmq modules
-Date: 2019-11-15
-Author: Fabio Tranchitella
-Category: Wazo Platform C4
-Tags: wazo-platform, c4, ha, kamailio, sip
-Slug: kamailio-ha-dispatcher-and-dmq
-Status: published
+---
+title: Kamailio HA: dispatcher and dmq modules
+date: 2019-11-15
+author: Fabio Tranchitella
+category: Wazo Platform C4
+tags: wazo-platform, c4, ha, kamailio, sip
+slug: kamailio-ha-dispatcher-and-dmq
+status: published
+---
 
 # Kamailio HA with dispatcher and dmq modules
 

--- a/content/blog/kamailio-routing-with-rtjson-and-http-async-client.md
+++ b/content/blog/kamailio-routing-with-rtjson-and-http-async-client.md
@@ -1,10 +1,12 @@
-Title: Kamailio routing with rtjson and http_async_client
-Date: 2019-11-11
-Author: Fabio Tranchitella
-Category: Wazo Platform C4
-Tags: wazo-platform, c4, kamailio, sip, routing
-Slug: kamailio-routing-with-rtjson-and-http-async-client
-Status: published
+---
+title: Kamailio routing with rtjson and http_async_client
+date: 2019-11-11
+author: Fabio Tranchitella
+category: Wazo Platform C4
+tags: wazo-platform, c4, kamailio, sip, routing
+slug: kamailio-routing-with-rtjson-and-http-async-client
+status: published
+---
 
 # Kamailio routing with RTJSON and HTTP async client
 

--- a/content/blog/live-transcript-demo-astricon-19.md
+++ b/content/blog/live-transcript-demo-astricon-19.md
@@ -1,10 +1,12 @@
-Title: Live Conversation Transcript
-Date: 2020-01-03
-Author: Pascal Cadotte Michaud
-Category: Wazo Platform
-Tags: wazo-platform, asterisk, stt, astricon
-Slug: live-transcript-demo-astricon-19
-Status: published
+---
+title: Live Conversation Transcript
+date: 2020-01-03
+author: Pascal Cadotte Michaud
+category: Wazo Platform
+tags: wazo-platform, asterisk, stt, astricon
+slug: live-transcript-demo-astricon-19
+status: published
+---
 
 # Live Conversation Transcript
 

--- a/content/blog/new-community-forum.md
+++ b/content/blog/new-community-forum.md
@@ -1,10 +1,12 @@
-Title: New community forum
-Date: 2019-11-21
-Author: Rémy Garrigue
-Category: Wazo Platform
-Tags: wazo-platform, community
-Slug: new-community-forum
-Status: published
+---
+title: New community forum
+date: 2019-11-21
+author: Rémy Garrigue
+category: Wazo Platform
+tags: wazo-platform, community
+slug: new-community-forum
+status: published
+---
 
 # New community forum
 

--- a/content/blog/new-public-release-wazo-1913.md
+++ b/content/blog/new-public-release-wazo-1913.md
@@ -1,10 +1,12 @@
-Title: Introducing Wazo Platform 19.13
-Date: 2019-09-20
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: wazo-platform-1913
-Status: published
+---
+title: Introducing Wazo Platform 19.13
+date: 2019-09-20
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: wazo-platform-1913
+status: published
+---
 
 Hello Wazo community!
 

--- a/content/blog/pjsip-multi-tenant.md
+++ b/content/blog/pjsip-multi-tenant.md
@@ -1,10 +1,12 @@
-Title: A Multi Tenant API for PJSIP
-Date: 2020-03-03 14:00:00
-Author: Pascal Cadotte Michaud
-Category: Wazo Platform
-Tags: wazo-platform, asterisk, pjsip, voip, api
-Slug: pjsip-multi-tenant
-Status: published
+---
+title: A Multi Tenant API for PJSIP
+date: 2020-03-03 14:00:00
+author: Pascal Cadotte Michaud
+category: Wazo Platform
+tags: wazo-platform, asterisk, pjsip, voip, api
+slug: pjsip-multi-tenant
+status: published
+---
 
 # Towards a Multi Tenant API for PJSIP
 

--- a/content/blog/queuemetrics-partnership.md
+++ b/content/blog/queuemetrics-partnership.md
@@ -1,9 +1,12 @@
-Title: New partnership with Loway's Queuemetrics-Live
-Date: 2017-10-13
-Author: The Wazo Authors
-Category: Wazo
-Slug: wazo-queuemetrics-partnership
-Status: published
+---
+title: New partnership with Loway's Queuemetrics-Live
+date: 2017-10-13
+author: The Wazo Authors
+category: Wazo
+Tags:
+slug: wazo-queuemetrics-partnership
+status: published
+---
 
 We are proud to announce our successful integration with Loway's QueueMetrics-Live call-center suite.
 

--- a/content/blog/solving-the-emergency-call-priorization-issue-with-programmable-telecom.md
+++ b/content/blog/solving-the-emergency-call-priorization-issue-with-programmable-telecom.md
@@ -1,24 +1,24 @@
-Title: Solving the emergency call prioritization issue with programmable telecom
-Date: 2019-04-26 15:45:00
-Author: Jérome Pascal
-Category: Hackathon
-Tags: emergency, programmable telecom, hackathon, voip
-Slug: solving-the-emergency-call-prioritization-issue-with-programmable-telecom
-Status: published
-
-
+---
+title: Solving the emergency call prioritization issue with programmable telecom
+date: 2019-04-26 15:45:00
+author: Jérome Pascal
+category: Hackathon
+tags: emergency, programmable telecom, hackathon, voip
+slug: solving-the-emergency-call-prioritization-issue-with-programmable-telecom
+status: published
+---
 
 ## A CRITICAL PAIN POINT FOR EMERGENCY CALL SERVICES
 
 With the advent of the ubiquitous cell phone, the task of the emergency contact centers to prioritize a huge number of calls has become a tough challenge. The kind of challenge that needs to aggregate heterogenous pieces of technology to be addressed efficiently.
 
-In the past, when a damaging event would occur - may it be a car accident, a terrorist attack or a climate disaster - only a limited number of people went to the nearby pharmacy or to the closest phone booth to warn the emergency service. In these times, adequate staffing was not so difficult for emergency contact centers: the call operator capacity was a mere function of the number of incidents. 
+In the past, when a damaging event would occur - may it be a car accident, a terrorist attack or a climate disaster - only a limited number of people went to the nearby pharmacy or to the closest phone booth to warn the emergency service. In these times, adequate staffing was not so difficult for emergency contact centers: the call operator capacity was a mere function of the number of incidents.
 
-Now, with so many devices in so many hands, should a mishap take place in a crowded place, you can be sure that everyone will try to reach the emergency contact center at the same time. The operators are then overwhelmed by a large number of simultaneous calls which all convey inefficiently the same pieces of information. Bad luck for the absent-minded woodcutter who left his chain saw inappropriately on at the same time a terrorist attack is taking place: our clumsy woodcutter will not be able to reach any emergency operator. 
+Now, with so many devices in so many hands, should a mishap take place in a crowded place, you can be sure that everyone will try to reach the emergency contact center at the same time. The operators are then overwhelmed by a large number of simultaneous calls which all convey inefficiently the same pieces of information. Bad luck for the absent-minded woodcutter who left his chain saw inappropriately on at the same time a terrorist attack is taking place: our clumsy woodcutter will not be able to reach any emergency operator.
 
 The situation could be described as an unintended yet effective denial of service attack.
 
-We will show here, how in less than a 3-day period - during a short hackathon - a team of developers, with no prior knowledge of the Wazo programmable platform, was able to put in place an effective solution to this prioritization issue, and save lives. 
+We will show here, how in less than a 3-day period - during a short hackathon - a team of developers, with no prior knowledge of the Wazo programmable platform, was able to put in place an effective solution to this prioritization issue, and save lives.
 
 
 ## DEMONSTRATION OF THE FLEXIBILITY AND SIMPLICITY OF USE OF THE WAZO PROGRAMMABLE PLATFORM
@@ -40,7 +40,7 @@ In the afternoon, it was agreed to build a mini emergency call center that could
 All this, of course, in full web with a phone using WebRTC.
 
 
-## HOW DID IT GO? 
+## HOW DID IT GO?
 
 We formed several groups of people according to their favourite taste: C lovers, Python devotees or JavaScript aficionados.
 
@@ -50,7 +50,7 @@ Our initial plan was that, during a call, we would:
 - Send it to a tool to transcribe the feed into text;
 - Then notify the result of the text analysis in the Wazo websocket service.
 
-Unfortunately, it was not possible to do this, based directly on Asterisk. Still, there were existing alternative ways to proceed: 
+Unfortunately, it was not possible to do this, based directly on Asterisk. Still, there were existing alternative ways to proceed:
 
 - through EAGI;
 - through a project that can be found on GitHub: https://github.com/CyCoreSystems/audiosocket;
@@ -78,18 +78,18 @@ Source of this interface could be found here : <https://github.com/wazo-platform
 
 The next day, we started the dev phase, each group apart working on its own subject.
 
-In the afternoon, we already had all our functional pieces ready. Time had come to aggregate those pieces. The project seemed to progress well. But in the evening everything was still not glued together. The Asterisk module still returned some segfault because the first implementation was not robust enough. We were almost done with the second implementation at the beginning of the evening but… it was definitely high time to have a dinner! 
+In the afternoon, we already had all our functional pieces ready. Time had come to aggregate those pieces. The project seemed to progress well. But in the evening everything was still not glued together. The Asterisk module still returned some segfault because the first implementation was not robust enough. We were almost done with the second implementation at the beginning of the evening but… it was definitely high time to have a dinner!
 
-The next and last day, we first showcased to the participants our internal daily routine (daily scrum). After that, it took us no more than 15 minutes to have our demo up and running. 
+The next and last day, we first showcased to the participants our internal daily routine (daily scrum). After that, it took us no more than 15 minutes to have our demo up and running.
 
-Then began a very funny time when we could test and try our demo. We decided to play the “Neither yes, nor no” game. Once the call was picked up, the operator tried to push the guest to say either “Yes” or “No”. Whenever the guest said either of the two words, the call was automatically ended. 
+Then began a very funny time when we could test and try our demo. We decided to play the “Neither yes, nor no” game. Once the call was picked up, the operator tried to push the guest to say either “Yes” or “No”. Whenever the guest said either of the two words, the call was automatically ended.
 
 We had plenty of time to stage our demo. And we could indeed showcase our IVR speech keyword detection demo in front of our colleagues and soon-to-be colleagues who joined us in the evening. Everything went so well that it was finally decided during our sprint retrospective to share our work.
 
 
 ## FUNCTIONAL CONCLUSION
 
-This live speech-to-text keyword detection demo was a very basic - yet useful - way to help emergency call centers enhance the quality of their services. With the Wazo programmable platform, we offer the opportunity to develop much more sophisticated ways to deal with peak visitor encumbrance, including automatic platform scaling, location-based sorting and routing, coupling IVR and AI, … 
+This live speech-to-text keyword detection demo was a very basic - yet useful - way to help emergency call centers enhance the quality of their services. With the Wazo programmable platform, we offer the opportunity to develop much more sophisticated ways to deal with peak visitor encumbrance, including automatic platform scaling, location-based sorting and routing, coupling IVR and AI, …
 
 
 ## KEY TAKEAWAYS

--- a/content/blog/sprint-review-1616.md
+++ b/content/blog/sprint-review-1616.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 16.16
-Date: 2016-12-12
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1616
-Status: published
+---
+title: Sprint Review 16.16
+date: 2016-12-12
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1616
+status: published
+---
 
 Hello Wazo community! Here comes the first release of Wazo, Wazo 16.16!
 

--- a/content/blog/sprint-review-1701.md
+++ b/content/blog/sprint-review-1701.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 17.01
-Date: 2017-01-09
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1701
-Status: published
+---
+title: Sprint Review 17.01
+date: 2017-01-09
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1701
+status: published
+---
 
 Hello Wazo community! Here comes the release of Wazo 17.01!
 

--- a/content/blog/sprint-review-1702.md
+++ b/content/blog/sprint-review-1702.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 17.02
-Date: 2017-01-30
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1702
-Status: published
+---
+title: Sprint Review 17.02
+date: 2017-01-30
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1702
+status: published
+---
 
 Hello Wazo community! Here comes the release of Wazo 17.02!
 

--- a/content/blog/sprint-review-1703.md
+++ b/content/blog/sprint-review-1703.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 17.03
-Date: 2017-02-20
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1703
-Status: published
+---
+title: Sprint Review 17.03
+date: 2017-02-20
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1703
+status: published
+---
 
 Hello Wazo community! Here comes the release of Wazo 17.03!
 

--- a/content/blog/sprint-review-1704.md
+++ b/content/blog/sprint-review-1704.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 17.04
-Date: 2017-03-13
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1704
-Status: published
+---
+title: Sprint Review 17.04
+date: 2017-03-13
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1704
+status: published
+---
 
 Hello Wazo community! Here comes the release of Wazo 17.04!
 

--- a/content/blog/sprint-review-1705.md
+++ b/content/blog/sprint-review-1705.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 17.05
-Date: 2017-04-03
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1705
-Status: published
+---
+title: Sprint Review 17.05
+date: 2017-04-03
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1705
+status: published
+---
 
 Hello Wazo community! Here comes the release of Wazo 17.05!
 

--- a/content/blog/sprint-review-1706.md
+++ b/content/blog/sprint-review-1706.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 17.06
-Date: 2017-04-24
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1706
-Status: published
+---
+title: Sprint Review 17.06
+date: 2017-04-24
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1706
+status: published
+---
 
 Hello Wazo community! Here comes the release of Wazo 17.06!
 

--- a/content/blog/sprint-review-1707.md
+++ b/content/blog/sprint-review-1707.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 17.07
-Date: 2017-05-15
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1707
-Status: published
+---
+title: Sprint Review 17.07
+date: 2017-05-15
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1707
+status: published
+---
 
 Hello Wazo community! Here comes the release of Wazo 17.07!
 

--- a/content/blog/sprint-review-1708.md
+++ b/content/blog/sprint-review-1708.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 17.08
-Date: 2017-06-01
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1708
-Status: published
+---
+title: Sprint Review 17.08
+date: 2017-06-01
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1708
+status: published
+---
 
 Hello Wazo community! Here comes the release of Wazo 17.08!
 

--- a/content/blog/sprint-review-1709.md
+++ b/content/blog/sprint-review-1709.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 17.09
-Date: 2017-06-21
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1709
-Status: published
+---
+title: Sprint Review 17.09
+date: 2017-06-21
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1709
+status: published
+---
 
 Hello Wazo community! Here comes the release of Wazo 17.09!
 

--- a/content/blog/sprint-review-1710.md
+++ b/content/blog/sprint-review-1710.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 17.10
-Date: 2017-07-17
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1710
-Status: published
+---
+title: Sprint Review 17.10
+date: 2017-07-17
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1710
+status: published
+---
 
 Hello Wazo community! Here comes the release of Wazo 17.10!
 

--- a/content/blog/sprint-review-1711.md
+++ b/content/blog/sprint-review-1711.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 17.11
-Date: 2017-08-07
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1711
-Status: published
+---
+title: Sprint Review 17.11
+date: 2017-08-07
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1711
+status: published
+---
 
 Hello Wazo community! Here comes the release of Wazo 17.11!
 

--- a/content/blog/sprint-review-1712.md
+++ b/content/blog/sprint-review-1712.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 17.12
-Date: 2017-08-28
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1712
-Status: published
+---
+title: Sprint Review 17.12
+date: 2017-08-28
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1712
+status: published
+---
 
 Hello Wazo community! Here comes the release of Wazo 17.12!
 

--- a/content/blog/sprint-review-1713.md
+++ b/content/blog/sprint-review-1713.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 17.13
-Date: 2017-09-18
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1713
-Status: published
+---
+title: Sprint Review 17.13
+date: 2017-09-18
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1713
+status: published
+---
 
 Hello Wazo community! Here comes the release of Wazo 17.13!
 

--- a/content/blog/sprint-review-1714.md
+++ b/content/blog/sprint-review-1714.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 17.14
-Date: 2017-10-09
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1714
-Status: published
+---
+title: Sprint Review 17.14
+date: 2017-10-09
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1714
+status: published
+---
 
 Hello Wazo community! Here comes the release of Wazo 17.14!
 

--- a/content/blog/sprint-review-1715.md
+++ b/content/blog/sprint-review-1715.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 17.15
-Date: 2017-10-31
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1715
-Status: published
+---
+title: Sprint Review 17.15
+date: 2017-10-31
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1715
+status: published
+---
 
 Hello Wazo community! Here comes the release of Wazo 17.15!
 

--- a/content/blog/sprint-review-1716.md
+++ b/content/blog/sprint-review-1716.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 17.16
-Date: 2017-11-20
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1716
-Status: published
+---
+title: Sprint Review 17.16
+date: 2017-11-20
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1716
+status: published
+---
 
 Hello Wazo community! Here comes the release of Wazo 17.16!
 

--- a/content/blog/sprint-review-1717.md
+++ b/content/blog/sprint-review-1717.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 17.17
-Date: 2017-12-11
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1717
-Status: published
+---
+title: Sprint Review 17.17
+date: 2017-12-11
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1717
+status: published
+---
 
 Hello Wazo community!
 

--- a/content/blog/sprint-review-1801.md
+++ b/content/blog/sprint-review-1801.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 18.01
-Date: 2018-01-22
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1801
-Status: published
+---
+title: Sprint Review 18.01
+date: 2018-01-22
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1801
+status: published
+---
 
 ## New features in this sprint
 

--- a/content/blog/sprint-review-1802.md
+++ b/content/blog/sprint-review-1802.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 18.02
-Date: 2018-02-12
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1802
-Status: published
+---
+title: Sprint Review 18.02
+date: 2018-02-12
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1802
+status: published
+---
 
 ## New features in this sprint
 

--- a/content/blog/sprint-review-1803.md
+++ b/content/blog/sprint-review-1803.md
@@ -1,10 +1,12 @@
-Title: Sprint Review 18.03
-Date: 2018-03-05
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, development
-Slug: sprint-review-1803
-Status: published
+---
+title: Sprint Review 18.03
+date: 2018-03-05
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, development
+slug: sprint-review-1803
+status: published
+---
 
 ## New features in this sprint
 

--- a/content/blog/sprint-review-1915.md
+++ b/content/blog/sprint-review-1915.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 19.15 Released
-Date: 2019-11-04
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: sprint-review-1915
-Status: published
+---
+title: Wazo Platform 19.15 Released
+date: 2019-11-04
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: sprint-review-1915
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-1916.md
+++ b/content/blog/sprint-review-1916.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 19.16 Released
-Date: 2019-11-18
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: sprint-review-1916
-Status: published
+---
+title: Wazo Platform 19.16 Released
+date: 2019-11-18
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: sprint-review-1916
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-1917.md
+++ b/content/blog/sprint-review-1917.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 19.17 Released
-Date: 2019-12-09
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: sprint-review-1917
-Status: published
+---
+title: Wazo Platform 19.17 Released
+date: 2019-12-09
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: sprint-review-1917
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2001.md
+++ b/content/blog/sprint-review-2001.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 20.01 Released
-Date: 2020-01-14
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: sprint-review-2001
-Status: published
+---
+title: Wazo Platform 20.01 Released
+date: 2020-01-14
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: sprint-review-2001
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2002.md
+++ b/content/blog/sprint-review-2002.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 20.02 Released
-Date: 2020-02-03
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2002
-Status: published
+---
+title: Wazo Platform 20.02 Released
+date: 2020-02-03
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2002
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2003.md
+++ b/content/blog/sprint-review-2003.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 20.03 Released
-Date: 2020-02-24
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2003
-Status: published
+---
+title: Wazo Platform 20.03 Released
+date: 2020-02-24
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2003
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2004.md
+++ b/content/blog/sprint-review-2004.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 20.04 Released
-Date: 2020-03-16
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2004
-Status: published
+---
+title: Wazo Platform 20.04 Released
+date: 2020-03-16
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2004
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2005.md
+++ b/content/blog/sprint-review-2005.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 20.05 Released
-Date: 2020-04-08
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2005
-Status: published
+---
+title: Wazo Platform 20.05 Released
+date: 2020-04-08
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2005
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2006.md
+++ b/content/blog/sprint-review-2006.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 20.06 Released
-Date: 2020-04-27
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2006
-Status: published
+---
+title: Wazo Platform 20.06 Released
+date: 2020-04-27
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2006
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2007.md
+++ b/content/blog/sprint-review-2007.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 20.07 Released
-Date: 2020-05-19
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2007
-Status: published
+---
+title: Wazo Platform 20.07 Released
+date: 2020-05-19
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2007
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2008.md
+++ b/content/blog/sprint-review-2008.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 20.08 Released
-Date: 2020-06-08
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2008
-Status: published
+---
+title: Wazo Platform 20.08 Released
+date: 2020-06-08
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2008
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2009.md
+++ b/content/blog/sprint-review-2009.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 20.09 Released
-Date: 2020-06-29
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2009
-Status: published
+---
+title: Wazo Platform 20.09 Released
+date: 2020-06-29
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2009
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2010.md
+++ b/content/blog/sprint-review-2010.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 20.10 Released
-Date: 2020-07-20
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2010
-Status: published
+---
+title: Wazo Platform 20.10 Released
+date: 2020-07-20
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2010
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2011.md
+++ b/content/blog/sprint-review-2011.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 20.11 Released
-Date: 2020-08-07
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2011
-Status: published
+---
+title: Wazo Platform 20.11 Released
+date: 2020-08-07
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2011
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2012.md
+++ b/content/blog/sprint-review-2012.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 20.12 Released
-Date: 2020-08-31
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2012
-Status: published
+---
+title: Wazo Platform 20.12 Released
+date: 2020-08-31
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2012
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2013.md
+++ b/content/blog/sprint-review-2013.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 20.13 Released
-Date: 2020-09-28 12:00:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2013
-Status: published
+---
+title: Wazo Platform 20.13 Released
+date: 2020-09-28 12:00:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2013
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2014.md
+++ b/content/blog/sprint-review-2014.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 20.14 Released
-Date: 2020-10-21
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2014
-Status: published
+---
+title: Wazo Platform 20.14 Released
+date: 2020-10-21
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2014
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2015.md
+++ b/content/blog/sprint-review-2015.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 20.15 Released
-Date: 2020-11-09
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2015
-Status: published
+---
+title: Wazo Platform 20.15 Released
+date: 2020-11-09
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2015
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2016.md
+++ b/content/blog/sprint-review-2016.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 20.16 Released
-Date: 2020-12-01 12:00:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2016
-Status: published
+---
+title: Wazo Platform 20.16 Released
+date: 2020-12-01 12:00:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2016
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2017.md
+++ b/content/blog/sprint-review-2017.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 20.17 Released
-Date: 2020-12-21
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2017
-Status: published
+---
+title: Wazo Platform 20.17 Released
+date: 2020-12-21
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2017
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2101.md
+++ b/content/blog/sprint-review-2101.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 21.01 Released
-Date: 2021-01-25
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2101
-Status: published
+---
+title: Wazo Platform 21.01 Released
+date: 2021-01-25
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2101
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2102.md
+++ b/content/blog/sprint-review-2102.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 21.02 Released
-Date: 2021-02-15
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2102
-Status: published
+---
+title: Wazo Platform 21.02 Released
+date: 2021-02-15
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2102
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2103.md
+++ b/content/blog/sprint-review-2103.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 21.03 Released
-Date: 2021-03-08 16:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2103
-Status: published
+---
+title: Wazo Platform 21.03 Released
+date: 2021-03-08 16:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2103
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2104.md
+++ b/content/blog/sprint-review-2104.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 21.04 Released
-Date: 2021-03-29
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2104
-Status: published
+---
+title: Wazo Platform 21.04 Released
+date: 2021-03-29
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2104
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2105.md
+++ b/content/blog/sprint-review-2105.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 21.05 Released
-Date: 2021-04-20 12:00:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2105
-Status: published
+---
+title: Wazo Platform 21.05 Released
+date: 2021-04-20 12:00:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2105
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2106.md
+++ b/content/blog/sprint-review-2106.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 21.06 Released
-Date: 2021-05-10T16:00:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2106
-Status: published
+---
+title: Wazo Platform 21.06 Released
+date: 2021-05-10T16:00:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2106
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2107.md
+++ b/content/blog/sprint-review-2107.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 21.07 Released
-Date: 2021-05-28T17:31:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2107
-Status: published
+---
+title: Wazo Platform 21.07 Released
+date: 2021-05-28T17:31:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2107
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2108.md
+++ b/content/blog/sprint-review-2108.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 21.08 Released
-Date: 2021-06-21T13:00:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2108
-Status: published
+---
+title: Wazo Platform 21.08 Released
+date: 2021-06-21T13:00:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2108
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2109.md
+++ b/content/blog/sprint-review-2109.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 21.09 Released
-Date: 2021-07-12T16:29:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2109
-Status: published
+---
+title: Wazo Platform 21.09 Released
+date: 2021-07-12T16:29:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2109
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2110.md
+++ b/content/blog/sprint-review-2110.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 21.10 Released
-Date: 2021-08-02T12:00:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2110
-Status: published
+---
+title: Wazo Platform 21.10 Released
+date: 2021-08-02T12:00:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2110
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2111.md
+++ b/content/blog/sprint-review-2111.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 21.11 Released
-Date: 2021-08-24T19:31:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2111
-Status: published
+---
+title: Wazo Platform 21.11 Released
+date: 2021-08-24T19:31:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2111
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2112.md
+++ b/content/blog/sprint-review-2112.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 21.12 Released
-Date: 2021-09-13T12:47:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2112
-Status: published
+---
+title: Wazo Platform 21.12 Released
+date: 2021-09-13T12:47:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2112
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2113.md
+++ b/content/blog/sprint-review-2113.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 21.13 Released
-Date: 2021-10-04T19:16:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2113
-Status: published
+---
+title: Wazo Platform 21.13 Released
+date: 2021-10-04T19:16:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2113
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2114.md
+++ b/content/blog/sprint-review-2114.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 21.14 Released
-Date: 2021-10-22T19:02:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2114
-Status: published
+---
+title: Wazo Platform 21.14 Released
+date: 2021-10-22T19:02:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2114
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2115.md
+++ b/content/blog/sprint-review-2115.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 21.15 Released
-Date: 2021-11-15T08:00:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2115
-Status: published
+---
+title: Wazo Platform 21.15 Released
+date: 2021-11-15T08:00:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2115
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2116.md
+++ b/content/blog/sprint-review-2116.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 21.16 Released
-Date: 2021-12-03T15:14:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2116
-Status: published
+---
+title: Wazo Platform 21.16 Released
+date: 2021-12-03T15:14:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2116
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2201.md
+++ b/content/blog/sprint-review-2201.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 22.01 Released
-Date: 2022-01-03T14:00:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2201
-Status: published
+---
+title: Wazo Platform 22.01 Released
+date: 2022-01-03T14:00:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2201
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2202.md
+++ b/content/blog/sprint-review-2202.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 22.02 Released
-Date: 2022-01-31T12:00:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2202
-Status: published
+---
+title: Wazo Platform 22.02 Released
+date: 2022-01-31T12:00:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2202
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2203.md
+++ b/content/blog/sprint-review-2203.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 22.03 Released
-Date: 2022-02-21T16:04:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2203
-Status: published
+---
+title: Wazo Platform 22.03 Released
+date: 2022-02-21T16:04:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2203
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2204.md
+++ b/content/blog/sprint-review-2204.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 22.04 Released
-Date: 2022-03-14T08:00:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2204
-Status: published
+---
+title: Wazo Platform 22.04 Released
+date: 2022-03-14T08:00:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2204
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2205.md
+++ b/content/blog/sprint-review-2205.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 22.05 Released
-Date: 2022-04-04T19:47:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2205
-Status: published
+---
+title: Wazo Platform 22.05 Released
+date: 2022-04-04T19:47:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2205
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2206.md
+++ b/content/blog/sprint-review-2206.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 22.06 Released
-Date: 2022-04-20T15:22:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2206
-Status: published
+---
+title: Wazo Platform 22.06 Released
+date: 2022-04-20T15:22:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2206
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2207.md
+++ b/content/blog/sprint-review-2207.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 22.07 Released
-Date: 2022-05-11T17:11:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2207
-Status: published
+---
+title: Wazo Platform 22.07 Released
+date: 2022-05-11T17:11:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2207
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2208.md
+++ b/content/blog/sprint-review-2208.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 22.08 Released
-Date: 2022-06-06T13:00:00+0400
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2208
-Status: published
+---
+title: Wazo Platform 22.08 Released
+date: 2022-06-06T13:00:00+0400
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2208
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2209.md
+++ b/content/blog/sprint-review-2209.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 22.09 Released
-Date: 2022-06-21T21:08:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2209
-Status: published
+---
+title: Wazo Platform 22.09 Released
+date: 2022-06-21T21:08:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2209
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2210.md
+++ b/content/blog/sprint-review-2210.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 22.10 Released
-Date: 2022-07-18T20:19:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2210
-Status: published
+---
+title: Wazo Platform 22.10 Released
+date: 2022-07-18T20:19:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2210
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2211.md
+++ b/content/blog/sprint-review-2211.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 22.11 Released
-Date: 2022-08-03T15:56:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2211
-Status: published
+---
+title: Wazo Platform 22.11 Released
+date: 2022-08-03T15:56:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2211
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2212.md
+++ b/content/blog/sprint-review-2212.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 22.12 Released
-Date: 2022-08-24T19:03:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2212
-Status: published
+---
+title: Wazo Platform 22.12 Released
+date: 2022-08-24T19:03:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2212
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2213.md
+++ b/content/blog/sprint-review-2213.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 22.13 Released
-Date: 2022-09-19T19:03:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2213
-Status: published
+---
+title: Wazo Platform 22.13 Released
+date: 2022-09-19T19:03:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2213
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/sprint-review-2214.md
+++ b/content/blog/sprint-review-2214.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform 22.14 Released
-Date: 2022-10-11T23:24:00
-Author: The Wazo Authors
-Category: Wazo Platform
-Tags: wazo-platform, development
-Slug: release-review-2214
-Status: published
+---
+title: Wazo Platform 22.14 Released
+date: 2022-10-11T23:24:00
+author: The Wazo Authors
+category: Wazo Platform
+tags: wazo-platform, development
+slug: release-review-2214
+status: published
+---
 
 Hello Wazo Platform community!
 

--- a/content/blog/survey-2017.md
+++ b/content/blog/survey-2017.md
@@ -1,9 +1,11 @@
-Title: Survey
-Date: 2017-11-23
-Author: The Wazo Authors
-Category: Business
-Slug: survey-2017
-Status: published
+---
+title: Survey
+date: 2017-11-23
+author: The Wazo Authors
+category: Business
+slug: survey-2017
+status: published
+---
 
 *La version française suit*
 

--- a/content/blog/testing-interaction-between-mobile-applications.md
+++ b/content/blog/testing-interaction-between-mobile-applications.md
@@ -1,10 +1,12 @@
-Title: Testing Interactions Between Mobile Applications: A Bumpy Ride
-Date: 2019-02-22 13:14:00
-Author: Emmanuel QUENTIN
-Category: Wazo IPBX
-Tags: Mobile, testing
-Slug: testing-interaction-between-mobile-applications
-Status: published
+---
+title: Testing Interactions Between Mobile Applications: A Bumpy Ride
+date: 2019-02-22 13:14:00
+author: Emmanuel QUENTIN
+category: Wazo IPBX
+tags: Mobile, testing
+slug: testing-interaction-between-mobile-applications
+status: published
+---
 
 ![callkeep](https://user-images.githubusercontent.com/2076632/52963046-ca98b200-336c-11e9-8c82-590c0bed8839.gif)
 
@@ -25,7 +27,7 @@ Testing interactions on a single application is pretty straightforward: tap on a
 To launch another device, we needed another instance of `Detox`, and to call `launchApp` on its `device` attribute:
 ```js
 // Takes configuration from package.json (our tests are run with `yarn e2e:test:ios` or `yarn e2e:test:android` so can we check the environment variable `npm_lifecycle_event`)
-const deviceConfig = require('../package.json').detox.configurations[process.env.npm_lifecycle_event === 'e2e:test:ios' ? 'ios.sim.debug' : 'android.emu.debug']; 
+const deviceConfig = require('../package.json').detox.configurations[process.env.npm_lifecycle_event === 'e2e:test:ios' ? 'ios.sim.debug' : 'android.emu.debug'];
 const otherDetox = new Detox({ deviceConfig });
 await otherDetox.device.launchApp();
 
@@ -78,7 +80,7 @@ Another way to avoid this cache is to make a class from the module. Set the `inv
 // ...
 - this.expect = require('../../ios/expect');
 - this.expect.setInvocationManager(new InvocationManager(this.client));
-+ this.expect = new IosExpect(new InvocationManager(this.client));	
++ this.expect = new IosExpect(new InvocationManager(this.client));
 ```
 
 Jest is also aware of each method of our class and can mock them automatically!

--- a/content/blog/testing-interaction-between-mobile-applications.md
+++ b/content/blog/testing-interaction-between-mobile-applications.md
@@ -1,5 +1,5 @@
 ---
-title: Testing Interactions Between Mobile Applications: A Bumpy Ride
+title: "Testing Interactions Between Mobile Applications: A Bumpy Ride"
 date: 2019-02-22 13:14:00
 author: Emmanuel QUENTIN
 category: Wazo IPBX

--- a/content/blog/value-your-cdr-with-machine-learning.md
+++ b/content/blog/value-your-cdr-with-machine-learning.md
@@ -1,10 +1,12 @@
-Title: Value your CDR with Machine learning
-Date: 2021-09-17 17:00:00
-Author: Théo Boyer
-Category: Wazo Platform
-Tags: Asterisk, Applications, Stasis, Scalability, Machine Learning, Data Science
-Slug: value-cdr-machine-learning
-Status: published
+---
+title: Value your CDR with Machine learning
+date: 2021-09-17 17:00:00
+author: Théo Boyer
+category: Wazo Platform
+tags: Asterisk, Applications, Stasis, Scalability, Machine Learning, Data Science
+slug: value-cdr-machine-learning
+status: published
+---
 
 # Value your CDR with Machine learning
 The CDR service allows you to keep track of the activity going on your stack. It's a data source that could be valuable in numerous ways. In this article, we will see how to make value out of your CDR using machine learning.

--- a/content/blog/wazo-admin-ui.md
+++ b/content/blog/wazo-admin-ui.md
@@ -1,9 +1,11 @@
-Title: The new web interface of Wazo
-Date: 2017-05-11
-Author: The Wazo Authors
-Category: Wazo
-Slug: wazo-admin-ui
-Status: published
+---
+title: The new web interface of Wazo
+date: 2017-05-11
+author: The Wazo Authors
+category: Wazo
+slug: wazo-admin-ui
+status: published
+---
 
 Wazo 17.07 is the first release embedding the future replacement of the administration web interface of Wazo.
 

--- a/content/blog/wazo-asterisk-integration.md
+++ b/content/blog/wazo-asterisk-integration.md
@@ -1,10 +1,12 @@
-Title: How to configure Asterisk when Wazo does not implement a functionality
-Date: 2017-02-22
-Author: The Wazo Authors
-Category: Wazo IPBX
-Tags: wazo, asterisk
-Slug: wazo-asterisk-integration
-Status: published
+---
+title: How to configure Asterisk when Wazo does not implement a functionality
+date: 2017-02-22
+author: The Wazo Authors
+category: Wazo IPBX
+tags: wazo, asterisk
+slug: wazo-asterisk-integration
+status: published
+---
 
 # Customizing your Asterisk configuration on Wazo
 

--- a/content/blog/wazo-auth-refresh-token.md
+++ b/content/blog/wazo-auth-refresh-token.md
@@ -1,10 +1,12 @@
-Title: Refresh Token in Wazo
-Date: 2019-12-02
-Author: Pascal Cadotte Michaud
-Category: Wazo Platform
-Slug: wazo-auth-refresh-token
+---
+title: Refresh Token in Wazo
+date: 2019-12-02
+author: Pascal Cadotte Michaud
+category: Wazo Platform
+slug: wazo-auth-refresh-token
 tags: wazo-platform, api, authentication
-Status: published
+status: published
+---
 
 
 # Introduction

--- a/content/blog/wazo-c4-ansible.md
+++ b/content/blog/wazo-c4-ansible.md
@@ -1,10 +1,12 @@
-Title: Installing the Wazo Class 4 engine with Ansible
-Date: 2020-02-18
-Author: Fabio Tranchitella and Aleksandar Sosic
-Category: Wazo Platform C4
-Tags: wazo-platform, c4, ansible
-Slug: install-wazo-c4-with-ansible
-Status: published
+---
+title: Installing the Wazo Class 4 engine with Ansible
+date: 2020-02-18
+author: Fabio Tranchitella and Aleksandar Sosic
+category: Wazo Platform C4
+tags: wazo-platform, c4, ansible
+slug: install-wazo-c4-with-ansible
+status: published
+---
 
 
 # Installing the Wazo Class 4 engine with Ansible

--- a/content/blog/wazo-c4-kubernetes.md
+++ b/content/blog/wazo-c4-kubernetes.md
@@ -1,10 +1,12 @@
-Title: Wazo Platform C4 now deployable on Kubernetes
-Date: 2019-11-26
-Author: Fabio Tranchitella and Aleksandar Sosic
-Category: Wazo Platform C4
-Tags: wazo-platform, c4, kubernetes, docker, cloud
-Slug: wazo-platform-c4-on-kubernetes
-Status: published
+---
+title: Wazo Platform C4 now deployable on Kubernetes
+date: 2019-11-26
+author: Fabio Tranchitella and Aleksandar Sosic
+category: Wazo Platform C4
+tags: wazo-platform, c4, kubernetes, docker, cloud
+slug: wazo-platform-c4-on-kubernetes
+status: published
+---
 
 
 # Wazo Platform C4 now deployable on Kubernetes

--- a/content/blog/wazo-new-logo.md
+++ b/content/blog/wazo-new-logo.md
@@ -1,9 +1,11 @@
-Title: Voici notre nouveau logo
-Date: 2017-06-07
-Author: Sylvain Boily
-Category: Wazo
-Slug: wazo-new-logo-fr
-Status: published
+---
+title: Voici notre nouveau logo
+date: 2017-06-07
+author: Sylvain Boily
+category: Wazo
+slug: wazo-new-logo-fr
+status: published
+---
 
 
 Nous sommes très fiers de vous dévoiler notre nouveau logo pour Wazo ! Sans plus attendre le voici :)

--- a/content/blog/wazo-ngrok-en.md
+++ b/content/blog/wazo-ngrok-en.md
@@ -1,9 +1,11 @@
-Title: Ngrok and Wazo integration
-Date: 2017-05-26
-Author: Sylvain Boily
-Category: Wazo
-Slug: wazo-ngrok-en
-Status: published
+---
+title: Ngrok and Wazo integration
+date: 2017-05-26
+author: Sylvain Boily
+category: Wazo
+slug: wazo-ngrok-en
+status: published
+---
 
 Cliquez [ici](http://blog.wazo.community/wazo-ngrok-fr.html) pour la version française.
 

--- a/content/blog/wazo-ngrok.md
+++ b/content/blog/wazo-ngrok.md
@@ -1,9 +1,11 @@
-Title: Ngrok s'invite dans Wazo
-Date: 2017-05-26
-Author: Sylvain Boily
-Category: Wazo
-Slug: wazo-ngrok-fr
-Status: published
+---
+title: Ngrok s'invite dans Wazo
+date: 2017-05-26
+author: Sylvain Boily
+category: Wazo
+slug: wazo-ngrok-fr
+status: published
+---
 
 Click [here](http://blog.wazo.community/wazo-ngrok-en.html) for the english version.
 

--- a/content/blog/wazo-platform-c4-overview.md
+++ b/content/blog/wazo-platform-c4-overview.md
@@ -1,16 +1,18 @@
-Title: Wazo Platform C4 overview
-Date: 2019-10-28
-Author: Aleksandar Sosic and Fabio Tranchitella
-Category: Wazo C4
-Tags: wazo-platform, c4
-Slug: wazo-platform-c4-overview
-Status: published
+---
+title: Wazo Platform C4 overview
+date: 2019-10-28
+author: Aleksandar Sosic and Fabio Tranchitella
+category: Wazo C4
+tags: wazo-platform, c4
+slug: wazo-platform-c4-overview
+status: published
+---
 
 # Wazo Platform C4 overview
 
 ## Introduction
 
-Wazo Platform allows you to build your own IP communication infrastructure and deliver innovative communication services. Fully open-source, API-centric, Cloud-native & multi-tenant, the project is designed around the famous open-source frameworks [Asterisk](https://www.asterisk.org/) & [Kamailio](https://www.kamailio.org/w/). 
+Wazo Platform allows you to build your own IP communication infrastructure and deliver innovative communication services. Fully open-source, API-centric, Cloud-native & multi-tenant, the project is designed around the famous open-source frameworks [Asterisk](https://www.asterisk.org/) & [Kamailio](https://www.kamailio.org/w/).
 
 If you want to know more about Wazo Platform, we encourage you to discover [Frédéric Lepied's presentation introduced at the Astricon 2019](https://www.slideshare.net/flepied/wazo-platform-astricon19).
 

--- a/content/blog/wazo-unicom-en.md
+++ b/content/blog/wazo-unicom-en.md
@@ -1,9 +1,11 @@
-Title: No hardware for your phone system?
-Date: 2017-06-12
-Author: Sylvain Boily
-Category: Wazo
-Slug: wazo-unicom-en
-Status: published
+---
+title: No hardware for your phone system?
+date: 2017-06-12
+author: Sylvain Boily
+category: Wazo
+slug: wazo-unicom-en
+status: published
+---
 
 
 I am asked quite regularly the difference between XiVO and Wazo in terms of features. There are now many, but one of the first that we implemented was simply to provide a completely user-oriented web interface to manage your day to day telephony. The development of this interface was completely web-based, using our APIs and meant to be "cloud" based. It had to be simple to use, easy to set up and mobility was a requirement. Finally Unicom was born.

--- a/content/blog/wazo-unicom-fr.md
+++ b/content/blog/wazo-unicom-fr.md
@@ -1,9 +1,11 @@
-Title: Un système de téléphonie sans matériel ?
-Date: 2017-06-12
-Author: Sylvain Boily
-Category: Wazo
-Slug: wazo-unicom-fr
-Status: published
+---
+title: Un système de téléphonie sans matériel ?
+date: 2017-06-12
+author: Sylvain Boily
+category: Wazo
+slug: wazo-unicom-fr
+status: published
+---
 
 
 On me demande assez régulièrement la différence entre XiVO et Wazo en terme de fonctionnalités. Il en existe maintenant beaucoup, mais une des premières que nous avons mises en œuvre était tout simplement de fournir une interface complètement web orientée utilisateur pour gérer sa téléphonie de tous les jours. Le développement de cette interface se voulait complètement web, utilisant nos APIs et aussi orienté vers l'aspect "CLOUD". Il fallait que cela soit simple à utiliser, simple à mettre en place et que la mobilité soit au rendez-vous. Finalement Unicom est né.

--- a/content/blog/wazo-webhooks.md
+++ b/content/blog/wazo-webhooks.md
@@ -1,9 +1,11 @@
-Title: Webhook coming in Wazo
-Date: 2017-05-18
-Author: Sylvain Boily
-Category: Wazo
-Slug: wazo-webhook
-Status: published
+---
+title: Webhook coming in Wazo
+date: 2017-05-18
+author: Sylvain Boily
+category: Wazo
+slug: wazo-webhook
+status: published
+---
 
 Depuis plusieurs mois nous travaillons activement pour améliorer Wazo et le rendre le plus ouvert possible. La dernière version 17.07 mets en lumière nos derniers travaux et nos développements actuels autour de Wazo.  Vous découvrirez ainsi : une nouvelle interface web basée sur nos APIs REST, une place de marché pour permettre d'étendre Wazo facilement, des nouvelles fonctionnalités comme les menus vocaux, les lignes multiples pour un utilisateur, etc.
 

--- a/content/blog/webrtc-demo.md
+++ b/content/blog/webrtc-demo.md
@@ -1,10 +1,12 @@
-Title: Creating our WebRTC demo
-Date: 2021-11-16 10:00:00
-Author: Manon Gerray
-Category: Wazo Platform
-Tags: wazo platform, webrtc, front-end
-Slug: creating-our-webrtc-demo
-Status: published
+---
+title: Creating our WebRTC demo
+date: 2021-11-16 10:00:00
+author: Manon Gerray
+category: Wazo Platform
+tags: wazo platform, webrtc, front-end
+slug: creating-our-webrtc-demo
+status: published
+---
 
 ## Introduction
 
@@ -68,7 +70,7 @@ const updateScenes = status => {
   $('#calls-handler').html('');
 
   ///[...]
-  
+
   Object.keys(sessions).forEach(sessionId => {
     const callSession = sessions[sessionId];
     const newScene = addScene(callSession, callSession.cameraEnabled);
@@ -94,7 +96,7 @@ const switchCall = event => {
 
   const sessionId = $(event.target).attr('data-sessionid');
   const callSession = sessions[sessionId];
-  
+
   if (currentSession.is(callSession)) {
     console.log('active call, no switching');
     return;

--- a/content/tutorials/authenticate-user-wazo-api.md
+++ b/content/tutorials/authenticate-user-wazo-api.md
@@ -1,11 +1,13 @@
-Title: How to Authenticate a User From Wazo APIs
-Date: 2022-06-22 10:00:00
-Author: Pascal Cadotte Michaud
-Category: Developer Tutorial
-Slug: authenticate-user-wazo-api
-OgImage: authenticate-user-wazo-api-og.jpg
-Thumbnail: authenticate-user-wazo-api-thumbnail.jpg
-Status: published
+---
+title: How to Authenticate a User From Wazo APIs
+date: 2022-06-22 10:00:00
+author: Pascal Cadotte Michaud
+category: Developer Tutorial
+slug: authenticate-user-wazo-api
+ogimage: authenticate-user-wazo-api-og.jpg
+thumbnail: authenticate-user-wazo-api-thumbnail.jpg
+status: published
+---
 
 ## Introduction
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -71,7 +71,7 @@ const getArticles = async (graphql, newPageRef) => {
           fileAbsolutePath: { regex: "/blog/" },
           frontmatter: { status: { eq: "published" } }
         }
-        sort: { fields: [frontmatter___title], order: ASC }
+        sort: { fields: [frontmatter___date], order: DESC }
       ) {
         edges {
           node {

--- a/src/component/blog/article.js
+++ b/src/component/blog/article.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import Layout from '../Layout';
-import ReactMarkdown from 'react-markdown';
 import { Link } from 'gatsby';
 
-const Page = ({ pageContext: { title, author, tags: tagsRaw, date: dateRaw, category, body } }) => {
+import Layout from '../Layout';
+
+const Page = ({ pageContext: { title, author, tags: tagsRaw, date: dateRaw, category, content } }) => {
   const date = new Date(dateRaw);
   const formattedDate = `${date.getDate()} ${date.toLocaleString('default', { month: 'long' })} ${date.getFullYear()}`;
   const tags = tagsRaw && tagsRaw.split(',');
@@ -12,7 +12,7 @@ const Page = ({ pageContext: { title, author, tags: tagsRaw, date: dateRaw, cate
     <Layout pageTitle={title} pageTitleDate={formattedDate} className="article" section="blog">
       <div className="container main">
         <div className="article--content">
-          <ReactMarkdown children={body} />
+          <div dangerouslySetInnerHTML={{ __html: content}} />
 
           <div className="article--content--footer">
             <Link className="article--content--footer-author" to="/blog" state={{ filter: { type: 'author', value: author }}}>{author}</Link>
@@ -27,4 +27,5 @@ const Page = ({ pageContext: { title, author, tags: tagsRaw, date: dateRaw, cate
     </Layout>
   );
 }
+
 export default Page

--- a/src/component/blog/index.js
+++ b/src/component/blog/index.js
@@ -1,21 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import Layout from '../Layout';
 import { Link } from 'gatsby';
 
-const sortArticles = a => a.sort((a, b) => {
-  const dateA = new Date(a.date);
-  const dateB = new Date(b.date);
-  if(dateA > dateB) return -1;
-  if(dateA < dateB) return 1;
-  return 0;
-});
+import Layout from '../Layout';
 
 const Page = ({ location, pageContext: { articles: articlesRaw  } }) => {
   const [ filter, setFilter ] = useState(location?.state?.filter || {});
   const [ articles, setArticles ] = useState(articlesRaw);
-
-  // sort articles
-  sortArticles(articles);
 
   useEffect(() => {
     const { value: newFilterValue, type: newFilterType } = location?.state?.filter || {};

--- a/src/component/blog/index.js
+++ b/src/component/blog/index.js
@@ -11,45 +11,54 @@ const sortArticles = a => a.sort((a, b) => {
 });
 
 const Page = ({ location, pageContext: { articles: articlesRaw  } }) => {
-  const [ filter, setFilter ] = useState((location.state && location.state.filter) || {}); 
-  const [ articles, setArticles ] = useState(articlesRaw); 
+  const [ filter, setFilter ] = useState(location?.state?.filter || {});
+  const [ articles, setArticles ] = useState(articlesRaw);
 
   // sort articles
   sortArticles(articles);
 
   useEffect(() => {
+    const { value: newFilterValue, type: newFilterType } = location?.state?.filter || {};
+    setFilter(location?.state?.filter);
+
     // filter articles
-    let a;
-    switch (filter.type) {
+    let filtredArticles;
+    switch (newFilterType) {
       case 'category':
-        a = articlesRaw.filter(item => item.category === filter.value);
+        filtredArticles = articlesRaw.filter(item => item.category === newFilterValue);
         break;
+
       case 'author':
-        a = articlesRaw.filter(item => item.author === filter.value);
+        filtredArticles = articlesRaw.filter(item => item.author === newFilterValue);
         break;
+
       case 'tag':
-        a = articlesRaw.filter(item => {
+        filtredArticles = articlesRaw.filter(item => {
           const tags = item.tags && item.tags.split(',');
-          return tags && tags.length && tags.includes(filter.value);
+          console.log(`🤠 -> useEffect -> tags`, tags);
+          return tags && tags.length && tags.includes(newFilterValue);
         });
         break;
+
       default:
-        a = articlesRaw;
+        filtredArticles = articlesRaw;
     }
 
-    setArticles(a);
-  }, [filter, articlesRaw])
+    setArticles(filtredArticles);
+  }, [location?.state?.filter, articlesRaw])
 
   return (
     <Layout pageTitle="Blog" section="blog" className="blog">
       <div className="container">
-      {filter.type && <div className="filter">Filtering by {filter.type}: {filter.value} <div role="button" tabIndex="0"onClick={() => setFilter({})} onKeyPress={() => setFilter({})}>Reset filter</div></div>}
+        { filter?.type && (
+          <div className="filter">Filtering by {filter?.type}: {filter?.value} <Link className="reset-filter" to="/blog" state={{ filter: { }}}>Reset filter</Link></div>
+        )}
         <div className="articles">
           {articles.map(({ title, slug, date: dateRaw, author, category, tags: tagsRaw, summary }) => {
             const date = new Date(dateRaw);
             const formattedDate = `${date.getDate()} ${date.toLocaleString('default', { month: 'long' })} ${date.getFullYear()}`;
             const tags = tagsRaw && tagsRaw.split(',');
- 
+
             return <div key={slug} className="item">
               <Link to={`/blog/${slug}`} className="title">{title}</Link>
               <div className="summary">{summary}...</div>
@@ -59,12 +68,12 @@ const Page = ({ location, pageContext: { articles: articlesRaw  } }) => {
                 by <Link className="hilite" to="/blog" state={{ filter: { type: 'author', value: author }}}>{author}</Link>  {" "}
                 {tags && tags.length &&
                   <span className="tags"> * Tagged with {tags.map(item => <Link key={item} className="hilite" to="/blog" state={{ filter: { type: 'tag', value: item }}}>{item}</Link>)}</span>}
-              </div> 
-            </div>; 
+              </div>
+            </div>;
           })}
         </div>
       </div>
-      
+
     </Layout>
   );
 }

--- a/src/component/tutorials/index.js
+++ b/src/component/tutorials/index.js
@@ -2,17 +2,8 @@ import React, { useState } from 'react';
 import Layout from '../Layout';
 import { Link } from 'gatsby';
 
-const sortTutorials = (a) =>
-  a.sort((a, b) => {
-    const dateA = new Date(a.date);
-    const dateB = new Date(b.date);
-    if (dateA > dateB) return -1;
-    if (dateA < dateB) return 1;
-    return 0;
-  });
-
-const Page = ({ pageContext: { tutorials: tutorialsRaw } }) => {
-  const [tutorials] = useState(sortTutorials(tutorialsRaw));
+const Tutorials = ({ pageContext: { tutorials: tutorialsRaw } }) => {
+  const [tutorials] = useState(tutorialsRaw);
 
   return (
     <Layout pageTitle="Tutorials" section="tutorials" className="tutorials">
@@ -33,4 +24,4 @@ const Page = ({ pageContext: { tutorials: tutorialsRaw } }) => {
   );
 };
 
-export default Page
+export default Tutorials

--- a/src/component/tutorials/tutorial.js
+++ b/src/component/tutorials/tutorial.js
@@ -1,16 +1,16 @@
 import Helmet from 'react-helmet';
 import React from 'react';
-import Layout from '../Layout';
-import ReactMarkdown from 'react-markdown';
 
-const Page = ({ pageContext: { title, author, category, body, ogimage } }) => (
+import Layout from '../Layout';
+
+const Page = ({ pageContext: { title, author, category, content, ogimage } }) => (
   <Layout pageTitle={title} className="article" section="tutorials">
     <Helmet>
       {ogimage && <meta property="og:image" content={`https://wazo-platform.org/images/tutorials/${ogimage}`} />}
     </Helmet>
     <div className="container main">
       <div className="article--content">
-        <ReactMarkdown children={body} />
+        <div dangerouslySetInnerHTML={{ __html: content}} />
 
         <div className="article--content--footer">
           <span className="article--content--footer-author">{author}</span>

--- a/src/styles/platform/styles.scss
+++ b/src/styles/platform/styles.scss
@@ -432,8 +432,12 @@ body.documentation {
     font-style: italic;
     padding: 20px 0;
     border-bottom: 1px solid #ddd;
+
     a {
-      margin-left: 20px;
+      font-weight: bold;
+      display: block;
+      font-style: normal;
+      color: #98c451;
     }
   }
   .articles {


### PR DESCRIPTION
When I wrote #526 I saw that syntax highlight was not working in blog post.

**Summary of changes:**
- Support frontmatter (meta data) for some content (articles & tutorials)
- Use GraphQL to fetch content and use built-in markdown (articles & tutorials)
- Fix blog listing filter not working