### PR TITLE
remove queuemetric link

### DIFF
--- a/content/blog/queuemetrics-partnership.md
+++ b/content/blog/queuemetrics-partnership.md
@@ -30,6 +30,5 @@ Said Lorenzo Emilitri, Founder of Loway.
 Said Sylvain Boily, Wazo development team Leader.
 
 QueueMetrics call center suite is available both on premise and hosted cloud service.
-For more information about QueueMetrics visit the official website at [www.queuemetrics.com](https://www.queuemetrics.com/).
 
 For more information about the Wazo project visit [wazo.community](http://wazo.community/).


### PR DESCRIPTION
why: the bot checking for dead link always has a 403 response on this
link. Since we don't really care of this blog post (5 years old). We
don't want to spent time to investigate reason. So removing link seem
good enough solution