### PR TITLE
WAZO-2945 twistd to twistd3

### DIFF
--- a/content/uc-doc/contributors/debug_daemon.md
+++ b/content/uc-doc/contributors/debug_daemon.md
@@ -30,7 +30,7 @@ No debug mode in wazo-confgend.
 ## wazo-provd {#wazo-provd}
 
 ```shell
-twistd3 -no -u wazo-provd -g wazo-provd -r epoll --logger provd.main.twistd_logs wazo-provd -s -v
+twistd3 -no -u wazo-provd -g wazo-provd --logger provd.main.twistd_logs wazo-provd -s -v
 ```
 
 - `-s`: for logging to `stderr`

--- a/content/uc-doc/contributors/debug_daemon.md
+++ b/content/uc-doc/contributors/debug_daemon.md
@@ -22,7 +22,7 @@ systemctl stop monit.service
 ## wazo-confgend {#wazo-confgend}
 
 ```shell
-twistd -no -u wazo-confgend -g wazo-confgend --python=/usr/bin/wazo-confgend --logger wazo_confgend.bin.daemon.twistd_logs
+twistd3 -no -u wazo-confgend -g wazo-confgend --python=/usr/bin/wazo-confgend --logger wazo_confgend.bin.daemon.twistd_logs
 ```
 
 No debug mode in wazo-confgend.
@@ -30,7 +30,7 @@ No debug mode in wazo-confgend.
 ## wazo-provd {#wazo-provd}
 
 ```shell
-twistd -no -u wazo-provd -g wazo-provd -r epoll --logger provd.main.twistd_logs wazo-provd -s -v
+twistd3 -no -u wazo-provd -g wazo-provd -r epoll --logger provd.main.twistd_logs wazo-provd -s -v
 ```
 
 - `-s`: for logging to `stderr`

--- a/content/uc-doc/contributors/profile_python.md
+++ b/content/uc-doc/contributors/profile_python.md
@@ -29,7 +29,7 @@ Here's an example on how to profile wazo-auth for CPU/time usage:
    To profile wazo-confgend, you must use this command instead of the one above:
 
    ```shell
-   twistd -p test.profile --profiler=cprofile --savestats -no --python=/usr/bin/wazo-confgend
+   twistd3 -p test.profile --profiler=cprofile --savestats -no --python=/usr/bin/wazo-confgend
    ```
 
    Note that profiling multi-threaded program (wazo-agid, wazo-confd) doesn't work reliably.


### PR DESCRIPTION
https://wazo-dev.atlassian.net/browse/WAZO-2945

Note that this is only relevant to debian-based installation, as it is the python3-twisted debian package that provides the `twistd3` binary to avoid conflict with python 2 installations of twisted(python-twisted in buster and earlier).

The doc will need to be updated if the assumption of a debian installation changes(e.g. for a docker-based wazo stack) or if a future debian version changes this convention(as the python-twisted package is not provided in bullseye, so a conflict is not possible).