### PR TITLE
Additional Integration tests doc

### DIFF
--- a/content/contribute/code.md
+++ b/content/contribute/code.md
@@ -47,8 +47,8 @@ environment in the same state, no files laying around.
 
 You can execute unittests with the following command
 
-```ShellSession
-$ tox -epy37
+```shell
+tox -e py37
 ```
 
 ## Integration tests
@@ -57,21 +57,21 @@ Integration tests exercise a service as a black box. Each test uses
 the public API of the service to assert that it passes. Our
 integration tests use docker to avoid installing too many dependencies
 on your system. You can find the integration tests in the
-integration_tests directory of most repositories. Executing the
+`integration_tests` directory of most repositories. Executing the
 following command from the root directory of a project should execute
 all integration tests.
 
-```ShellSession
-$ tox -eintegration
+```shell
+tox -e integration
 ```
 
 If tox is not configured to execute integration tests, you can execute
 the following commands.
 
-```ShellSession
-$ cd integration_tests
-$ make test-setup
-$ make test
+```shell
+cd integration_tests
+make test-setup
+make test
 ```
 
 For more details see [integration tests documentation](/uc-doc/contributors/integration-tests.md)

--- a/content/contribute/code.md
+++ b/content/contribute/code.md
@@ -1,5 +1,4 @@
-How to contribute to Wazo Platform code base
-============================================
+# How to contribute to Wazo Platform code base
 
 In order to contribute to Wazo Platform you need to be able to
 retrieve the source code, edit the code, try your changes and contribute
@@ -58,7 +57,7 @@ Integration tests exercise a service as a black box. Each test uses
 the public API of the service to assert that it passes. Our
 integration tests use docker to avoid installing too many dependencies
 on your system. You can find the integration tests in the
-integration\_tests directory of most repositories. Executing the
+integration_tests directory of most repositories. Executing the
 following command from the root directory of a project should execute
 all integration tests.
 
@@ -74,6 +73,7 @@ $ cd integration_tests
 $ make test-setup
 $ make test
 ```
+
 For more details see [integration tests documentation](/uc-doc/contributors/integration-tests.md)
 
 ## Acceptance tests

--- a/content/contribute/code.md
+++ b/content/contribute/code.md
@@ -74,6 +74,7 @@ $ cd integration_tests
 $ make test-setup
 $ make test
 ```
+For more details see [integration tests documentation](/uc-doc/contributors/integration-tests.md)
 
 ## Acceptance tests
 

--- a/content/uc-doc/contributors/contributing_to_wazo.md
+++ b/content/uc-doc/contributors/contributing_to_wazo.md
@@ -52,7 +52,7 @@ repositories. A tox environment "integration" should be available, allowing inte
 run using the following command from the project root directory:
 
 ```shell
-tox -eintegration
+tox -e integration
 ```
 
 If `tox` is not configured to execute integration tests, you can execute the following commands.

--- a/content/uc-doc/contributors/contributing_to_wazo.md
+++ b/content/uc-doc/contributors/contributing_to_wazo.md
@@ -44,12 +44,12 @@ tox -e py37
 
 ### Integration tests {#integration-tests}
 
-Integration tests models a service under test as a black box with some interface.
-Those tests rely on the public API of the service and make assertions based on the observed behavior of that API.
-Those tests rely on docker and docker-compose to isolate the components under tests and their dependencies.
-You can find the integration tests in the `integration_tests` directory of most repositories.
-A tox environment "integration" should be available,
-allowing integration tests to be run using the following command from the project root directory:
+Integration tests models a service under test as a black box with some interface. Those tests rely
+on the public API of the service and make assertions based on the observed behavior of that API.
+Those tests rely on docker and docker-compose to isolate the components under tests and their
+dependencies. You can find the integration tests in the `integration_tests` directory of most
+repositories. A tox environment "integration" should be available, allowing integration tests to be
+run using the following command from the project root directory:
 
 ```shell
 tox -eintegration

--- a/content/uc-doc/contributors/contributing_to_wazo.md
+++ b/content/uc-doc/contributors/contributing_to_wazo.md
@@ -44,11 +44,12 @@ tox -e py37
 
 ### Integration tests {#integration-tests}
 
-Integration tests exercise a service as a black box. It uses the public API of the service and use
-the API to assert that the test passes. Our integration tests use docker to avoid installing too
-many dependencies on your system. You can find the integration tests in the `integration_tests`
-directory of most repository. Executing the following command from the root directory of a project
-should execute all integration tests.
+Integration tests models a service under test as a black box with some interface. 
+Those tests rely on the public API of the service and make assertions based on the observed behavior of that API. 
+Those tests rely on docker and docker-compose to isolate the components under tests and their dependencies. 
+You can find the integration tests in the `integration_tests` directory of most repositories. 
+A tox environment "integration" should be available, 
+allowing integration tests to be run using the following command from the project root directory: 
 
 ```shell
 tox -eintegration
@@ -61,6 +62,8 @@ cd integration_tests
 make test-setup
 make test
 ```
+For more details see [integration tests documentation](/uc-doc/contributors/integration-tests.md).
+
 
 ### Acceptance tests {#acceptance-tests}
 

--- a/content/uc-doc/contributors/contributing_to_wazo.md
+++ b/content/uc-doc/contributors/contributing_to_wazo.md
@@ -44,12 +44,12 @@ tox -e py37
 
 ### Integration tests {#integration-tests}
 
-Integration tests models a service under test as a black box with some interface. 
-Those tests rely on the public API of the service and make assertions based on the observed behavior of that API. 
-Those tests rely on docker and docker-compose to isolate the components under tests and their dependencies. 
-You can find the integration tests in the `integration_tests` directory of most repositories. 
-A tox environment "integration" should be available, 
-allowing integration tests to be run using the following command from the project root directory: 
+Integration tests models a service under test as a black box with some interface.
+Those tests rely on the public API of the service and make assertions based on the observed behavior of that API.
+Those tests rely on docker and docker-compose to isolate the components under tests and their dependencies.
+You can find the integration tests in the `integration_tests` directory of most repositories.
+A tox environment "integration" should be available,
+allowing integration tests to be run using the following command from the project root directory:
 
 ```shell
 tox -eintegration
@@ -62,8 +62,8 @@ cd integration_tests
 make test-setup
 make test
 ```
-For more details see [integration tests documentation](/uc-doc/contributors/integration-tests.md).
 
+For more details see [integration tests documentation](/uc-doc/contributors/integration-tests.md).
 
 ### Acceptance tests {#acceptance-tests}
 

--- a/content/uc-doc/contributors/integration-tests.md
+++ b/content/uc-doc/contributors/integration-tests.md
@@ -1,11 +1,9 @@
-# integration tests
-
 This document describes the conventional setup for per-component integration tests in wazo projects.
 
 ## Requirements
 
 The integration tests rely directly on docker(or an equivalent drop-in) and docker-compose,
-and assume that functional `docker-compose`[^1] and `docker`[^2] commands are available in the environment.
+and assume that functional [`docker-compose`](https://docs.docker.com/compose/) and [`docker`](https://docs.docker.com/) commands are available in the environment.
 
 Additional python dependencies(including test runners, frameworks and any tool and library used by the tests) are made available in
 a pip requirements.txt file, to be be installed into a specific virtual environment.
@@ -21,7 +19,7 @@ a pip requirements.txt file, to be be installed into a specific virtual environm
 - `integration_tests/test-requirements.txt` (or a differently named pip requirements file) should contain all python requirements required for the test environment, such as the test runner, and other tools and libraries used by the tests.
 - `integration_tests/Makefile` should exist and define an interface to interact with the test setup using the `make` utility.
 
-## Running tests
+## Running Tests
 
 A tox interface should be available, enabling integration tests to be executed from the project root directory through
 
@@ -46,23 +44,23 @@ make test
 
 ### pytest
 
-The tests suites usually use `pytest`[^3] as a test runner and framework, which should be made available through the test python requirements file.
+The tests suites usually use [`pytest`](https://docs.pytest.org/en/7.2.x/) as a test runner and framework, which should be made available through the test python requirements file.
 
 For example, to run a single test file and all tests contained:
 
-```
+```shell
 pytest suite/test_confgen.py
 ```
 
 To run all tests:
 
-```
+```shell
 pytest suite/
 ```
 
 and to run only tests matching a specific marker and a specified name pattern:
 
-```
+```shell
 pytest -m 'critical' -k 'pjsip_conf' suite/
 ```
 
@@ -91,7 +89,7 @@ To test that the image is functional:
 docker run --rm -it -v $(readlink ..):/usr/local/src/$projectname wazoplatform/$projectname:local
 ```
 
-(note this will mount the project root directory as a volume to provide in-development source code for testing).
+**Note**: This will mount the project root directory as a volume to provide in-development source code for testing)
 This should start a container from the built image, which should run the component entrypoint(usually a daemon implemented by the codebase).
 
 Once the image is made available locally, the docker-compose configurations should be able to use it and pull any other required images from the relevant registries.
@@ -132,7 +130,3 @@ docker-compose -f assets/docker-compose.yml -f assets/docker-compose.base.overri
 ### denv
 
 [denv](https://github.com/wazo-platform/denv) is a utility to simplify the usage patterns of docker-compose for integration tests.
-
-[^1]: https://docs.docker.com/compose/
-[^2]: https://docs.docker.com/
-[^3]: https://docs.pytest.org/en/7.2.x/

--- a/content/uc-doc/contributors/integration-tests.md
+++ b/content/uc-doc/contributors/integration-tests.md
@@ -2,33 +2,31 @@ This document describes the conventional setup for per-component integration tes
 
 ## Requirements
 
-The integration tests rely directly on docker(or an equivalent drop-in) and docker-compose, and
-assume that functional [`docker-compose`](https://docs.docker.com/compose/) and
-[`docker`](https://docs.docker.com/) commands are available in the environment.
+The integration tests rely directly on [`docker`](https://docs.docker.com/) and
+[`docker-compose`](https://docs.docker.com/compose/)
 
-Additional python dependencies(including test runners, frameworks and any tool and library used by
-the tests) are made available in a pip requirements.txt file, to be be installed into a specific
-virtual environment.
+Additional python dependencies (including test runners, frameworks and any tool and library used by
+the tests) are made available in a pip `integration_tests/test-requirements.txt` file, to be be
+installed into a specific virtual environment.
 
 ## Structure
-
-(As a general guide on conventional project structure, see also
-[Wazo daemon file structure](https://github.com/wazo-platform/wazo-notebook/blob/master/file-structure.md)
 
 - All files related to integration tests should be present under an `integration_tests` directory
   directly below a project root directory.
 - `integration_tests/assets` should contain docker-compose yaml files as well as configuration and
-  static assets required for tests at runtime(usually mounted as volumes configured in the compose
+  static assets required for tests at runtime (usually mounted as volumes configured in the compose
   files).
 - `integration_tests/docker` should contain custom dockerfiles and other files required to build
-  images for the test setup(referenced in compose files).
+  images for the test setup (referenced in compose files).
 - `integration_tests/suite` should contain the actual python tests definitions, including any custom
   helpers and utilities.
-- `integration_tests/test-requirements.txt` (or a differently named pip requirements file) should
-  contain all python requirements required for the test environment, such as the test runner, and
-  other tools and libraries used by the tests.
+- `integration_tests/test-requirements.txt` should contain all python requirements required for the
+  test environment, such as the test runner, and other tools and libraries used by the tests.
 - `integration_tests/Makefile` should exist and define an interface to interact with the test setup
   using the `make` utility.
+
+As a general guide on conventional project structure, see also
+[Wazo daemon file structure](https://github.com/wazo-platform/wazo-notebook/blob/master/file-structure.md)
 
 ## Running Tests
 
@@ -39,12 +37,12 @@ directory through
 tox -e integration
 ```
 
-tox takes care of creating the virtual environment containing the dependencies for the tests.
+`tox` takes care of creating the virtual environment containing the dependencies for the tests.
 
-The `integration_tests/Makefile` should define a target `test-setup` to prepare the test
-environment(e.g. build docker images), and a `test` target to run the tests. Those targets can be
-used directly, and should be used by the tox `integration` environment. To run the tests without tox
-from the `integration_tests` directory:
+The `integration_tests/Makefile` should define a target `test-setup` to prepare the test environment
+(e.g. build docker images), and a `test` target to run the tests. Those targets can be used
+directly, and should be used by the tox `integration` environment. To run the tests without tox from
+the `integration_tests` directory:
 
 ```shell
 # make test dependencies available in a virtual environment
@@ -56,8 +54,8 @@ make test
 
 ### pytest
 
-The tests suites usually use [`pytest`](https://docs.pytest.org/en/7.2.x/) as a test runner and
-framework, which should be made available through the test python requirements file.
+The tests suites usually use [`pytest`](https://docs.pytest.org) as a test runner and framework,
+which should be made available through the test python requirements file.
 
 For example, to run a single test file and all tests contained:
 
@@ -71,10 +69,10 @@ To run all tests:
 pytest suite/
 ```
 
-and to run only tests matching a specific marker and a specified name pattern:
+and to run only tests matching a specified name pattern:
 
 ```shell
-pytest -m 'critical' -k 'pjsip_conf' suite/
+pytest -k 'pjsip_conf' suite/
 ```
 
 ## Docker
@@ -82,8 +80,8 @@ pytest -m 'critical' -k 'pjsip_conf' suite/
 The tests rely on a containerized deployment of the codebase under test. The container image for the
 codebase can be built using the a dockerfile available in the `integration_tests/docker` directory.
 
-Current conventions prescribe the pattern `Dockerfile-$component` for the name of the dockerfiles,
-where `$component` might be a short name descriptive of the purpose of the image(e.g.
+Current conventions prescribe the pattern `Dockerfile-<service>` for the name of the dockerfiles,
+where `<service>` might be a short name descriptive of the purpose of the image (e.g.
 `Dockerfile-confgend` for a image for the confgend codebase).
 
 `make` targets should be defined in the `integration_tests/Makefile` to encapsulate the recipe for
@@ -94,24 +92,26 @@ To build the images directly, a docker invocation similar to the following can b
 `integration_tests` directory:
 
 ```shell
-docker build -f docker/$dockerfile -t wazoplatform/$projectname:local ..
+docker build -f docker/Dockerfile-<service> -t wazoplatform/<project-name>:local ..
 ```
 
-(the tag given with `-t` must match the image name expected by the corresponding service
-descriptions in the docker-compose files).
+The tag given with `-t` must match the image name expected by the corresponding service descriptions
+in the docker-compose files.
 
 To test that the image is functional:
 
 ```shell
-docker run --rm -it -v $(readlink ..):/usr/local/src/$projectname wazoplatform/$projectname:local
+docker run --rm -it -v $(readlink -f ..):/usr/local/src/<project-name> wazoplatform/<project-name>:local
 ```
 
 **Note**: This will mount the project root directory as a volume to provide in-development source
-code for testing) This should start a container from the built image, which should run the component
-entrypoint(usually a daemon implemented by the codebase).
+code for testing.
+
+This should start a container from the built image, which should run the component entrypoint
+(usually a daemon implemented by the codebase).
 
 Once the image is made available locally, the docker-compose configurations should be able to use it
-and pull any other required images from the relevant registries.
+and pull any other required images from the docker hub registry.
 
 ## docker-compose
 
@@ -119,7 +119,7 @@ The wazo test framework used by the test code takes care of controlling `docker-
 the services required by the tests. The `docker-compose` command can be used directly to debug and
 manually interact with the test setup.
 
-The docker-compose _stack_(all services and resources managed by docker-compose) is defined through
+The docker-compose _stack_ (all services and resources managed by docker-compose) is defined through
 multiple compose files. A base `docker-compose.yml` file is combined with override files which can
 offer different configuration profiles for the test environment. At a minimum, a
 `docker-compose.base.override.yml` would define the settings for a default "baseline" test
@@ -140,13 +140,13 @@ docker-compose -f assets/docker-compose.yml -f assets/docker-compose.base.overri
 To run a specific service and its dependencies:
 
 ```shell
-docker-compose -f assets/docker-compose.yml -f assets/docker-compose.base.override.yml run $service
+docker-compose -f assets/docker-compose.yml -f assets/docker-compose.base.override.yml run <service>
 ```
 
 To execute a command inside the container environment of a specific service already deployed:
 
 ```shell
-docker-compose -f assets/docker-compose.yml -f assets/docker-compose.base.override.yml exec $service $command
+docker-compose -f assets/docker-compose.yml -f assets/docker-compose.base.override.yml exec <service> <command>
 ```
 
 ### denv

--- a/content/uc-doc/contributors/integration-tests.md
+++ b/content/uc-doc/contributors/integration-tests.md
@@ -1,35 +1,41 @@
 # integration tests
+
 This document describes the conventional setup for per-component integration tests in wazo projects.
 
 ## Requirements
-The integration tests rely directly on docker(or an equivalent drop-in) and docker-compose, 
+
+The integration tests rely directly on docker(or an equivalent drop-in) and docker-compose,
 and assume that functional `docker-compose`[^1] and `docker`[^2] commands are available in the environment.
 
-Additional python dependencies(including test runners, frameworks and any tool and library used by the tests) are made available in 
+Additional python dependencies(including test runners, frameworks and any tool and library used by the tests) are made available in
 a pip requirements.txt file, to be be installed into a specific virtual environment.
 
 ## Structure
-(As a general guide on conventional project structure, see also [Wazo daemon file structure](https://github.com/wazo-platform/wazo-notebook/blob/master/file-structure.md) 
 
-All files related to integration tests should be present under an `integration_tests` directory directly below a project root directory.
-`integration_tests/assets` should contain docker-compose yaml files as well as configuration and static assets required for tests at runtime(usually mounted as volumes configured in the compose files).
-`integration_tests/docker` should contain custom dockerfiles and other files required to build images for the test setup(referenced in compose files). 
-`integration_tests/suite` should contain the actual python tests definitions, including any custom helpers and utilities.
-`integration_tests/test-requirements.txt` (or a differently named pip requirements file) should contain all python requirements required for the test environment, such as the test runner, and other tools and libraries used by the tests.
-`integration_tests/Makefile` should exist and define an interface to interact with the test setup using the `make` utility.
+(As a general guide on conventional project structure, see also [Wazo daemon file structure](https://github.com/wazo-platform/wazo-notebook/blob/master/file-structure.md)
+
+- All files related to integration tests should be present under an `integration_tests` directory directly below a project root directory.
+- `integration_tests/assets` should contain docker-compose yaml files as well as configuration and static assets required for tests at runtime(usually mounted as volumes configured in the compose files).
+- `integration_tests/docker` should contain custom dockerfiles and other files required to build images for the test setup(referenced in compose files).
+- `integration_tests/suite` should contain the actual python tests definitions, including any custom helpers and utilities.
+- `integration_tests/test-requirements.txt` (or a differently named pip requirements file) should contain all python requirements required for the test environment, such as the test runner, and other tools and libraries used by the tests.
+- `integration_tests/Makefile` should exist and define an interface to interact with the test setup using the `make` utility.
 
 ## Running tests
 
 A tox interface should be available, enabling integration tests to be executed from the project root directory through
+
 ```shell
 tox -e integration
 ```
+
 tox takes care of creating the virtual environment containing the dependencies for the tests.
 
 The `integration_tests/Makefile` should define a target `test-setup` to prepare the test environment(e.g. build docker images),
-and a `test` target to run the tests. 
+and a `test` target to run the tests.
 Those targets can be used directly, and should be used by the tox `integration` environment.
 To run the tests without tox from the `integration_tests` directory:
+
 ```shell
 # make test dependencies available in a virtual environment
 python3 -m venv .venv && pip install -r test-requirements.txt
@@ -43,73 +49,89 @@ make test
 The tests suites usually use `pytest`[^3] as a test runner and framework, which should be made available through the test python requirements file.
 
 For example, to run a single test file and all tests contained:
+
 ```
 pytest suite/test_confgen.py
 ```
+
 To run all tests:
+
 ```
 pytest suite/
 ```
+
 and to run only tests matching a specific marker and a specified name pattern:
+
 ```
 pytest -m 'critical' -k 'pjsip_conf' suite/
 ```
 
 ## Docker
+
 The tests rely on a containerized deployment of the codebase under test.
-The container image for the codebase can be built using the a dockerfile available in the `integration_tests/docker` directory. 
+The container image for the codebase can be built using the a dockerfile available in the `integration_tests/docker` directory.
 
 Current conventions prescribe the pattern `Dockerfile-$component` for the name of the dockerfiles, where `$component` might be a short name descriptive of the purpose of the image(e.g. `Dockerfile-confgend` for a image for the confgend codebase).
 
 `make` targets should be defined in the `integration_tests/Makefile` to encapsulate the recipe for building each image required for the tests.
 Those targets should be referenced as pre-requirements in the `test-setup` target.
 
-
-To build the images directly, a docker invocation similar to the following can be run 
+To build the images directly, a docker invocation similar to the following can be run
 from the `integration_tests` directory:
+
 ```shell
 docker build -f docker/$dockerfile -t wazoplatform/$projectname:local ..
 ```
+
 (the tag given with `-t` must match the image name expected by the corresponding service descriptions in the docker-compose files).
 
 To test that the image is functional:
+
 ```shell
 docker run --rm -it -v $(readlink ..):/usr/local/src/$projectname wazoplatform/$projectname:local
 ```
+
 (note this will mount the project root directory as a volume to provide in-development source code for testing).
 This should start a container from the built image, which should run the component entrypoint(usually a daemon implemented by the codebase).
 
 Once the image is made available locally, the docker-compose configurations should be able to use it and pull any other required images from the relevant registries.
 
-
 ## docker-compose
+
 The wazo test framework used by the test code takes care of controlling `docker-compose` to bring up the services required by the tests.
 The `docker-compose` command can be used directly to debug and manually interact with the test setup.
 
-The docker-compose *stack*(all services and resources managed by docker-compose) is defined through multiple compose files.
+The docker-compose _stack_(all services and resources managed by docker-compose) is defined through multiple compose files.
 A base `docker-compose.yml` file is combined with override files which can offer different configuration profiles for the test environment.
 At a minimum, a `docker-compose.base.override.yml` would define the settings for a default "baseline" test environment.
 
 To deploy the docker-compose stack for the base environment,
+
 ```shell
 docker-compose -f assets/docker-compose.yml -f assets/docker-compose.base.override.yml up
 ```
+
 Then to stop the services and cleanup active resources managed by docker-compose:
+
 ```shell
 docker-compose -f assets/docker-compose.yml -f assets/docker-compose.base.override.yml down
 ```
+
 To run a specific service and its dependencies:
+
 ```shell
 docker-compose -f assets/docker-compose.yml -f assets/docker-compose.base.override.yml run $service
 ```
+
 To execute a command inside the container environment of a specific service already deployed:
+
 ```shell
 docker-compose -f assets/docker-compose.yml -f assets/docker-compose.base.override.yml exec $service $command
 ```
 
 ### denv
-[denv](https://github.com/wazo-platform/denv) is a utility to simplify the usage patterns of docker-compose for integration tests.
 
+[denv](https://github.com/wazo-platform/denv) is a utility to simplify the usage patterns of docker-compose for integration tests.
 
 [^1]: https://docs.docker.com/compose/
 [^2]: https://docs.docker.com/

--- a/content/uc-doc/contributors/integration-tests.md
+++ b/content/uc-doc/contributors/integration-tests.md
@@ -1,0 +1,115 @@
+# integration tests
+This document describes the conventional setup for per-component integration tests in wazo projects.
+
+## Requirements
+The integration tests rely directly on docker(or an equivalent drop-in) and docker-compose, 
+and assume that functional `docker-compose`[^1] and `docker`[^2] commands are available in the environment.
+
+Required python dependencies are made available in the [test-requirements.txt](./test-requirements.txt) file, 
+which can(and should) be installed into a specific virtual environment.
+
+## Structure
+(As a general guide on conventional project structure, see also [Wazo daemon file structure](https://github.com/wazo-platform/wazo-notebook/blob/master/file-structure.md) 
+
+All files related to integration tests should be present under an `integration_tests` directory directly below a project root directory.
+`integration_tests/assets` should contain docker-compose yaml files as well as configuration and static assets required for tests at runtime(usually mounted as volumes configured in the compose files).
+`integration_tests/docker` should contain custom dockerfiles and other files required to build images for the test setup(referenced in compose files). 
+`integration_tests/suite` should contain the actual python tests definitions, including any custom helpers and utilities.
+`integration_tests/test-requirements.txt` (or a differently named pip requirements file) should contain all python requirements required for the test environment, such as the test runner, and other tools and libraries used by the tests.
+`integration_tests/Makefile` should exist and define an interface to interact with the test setup using the `make` utility.
+
+## Running tests
+
+A tox interface should be available, enabling integration tests to be executed from the project root directory through
+```shell
+tox -e integration
+```
+tox takes care of creating the virtual environment containing the dependencies for the tests.
+
+The `integration_tests/Makefile` should define a target `test-setup` to prepare the test environment(e.g. build docker images),
+and a `test` target to run the tests. Those targets can be used directly, and should be used by the tox `integration` environment.
+To run the tests without tox from the `integration_tests` directory:
+```shell
+# make test dependencies available in a virtual environment
+python3 -m venv .venv && pip install -r test-requirements.txt
+source .venv/bin/activate
+make test-setup
+make test
+```
+
+### pytest
+
+The tests suites usually use `pytest`[^3] as a test runner and framework, which should be made available through the test python requirements file.
+
+For example, to run a single test file and all tests contained:
+```
+pytest suite/test_confgen.py
+```
+To run all tests:
+```
+pytest suite/
+```
+and to run only tests matching a specific marker and a specified name pattern:
+```
+pytest -m 'critical' -k 'pjsip_conf' suite/
+```
+
+## Docker
+The tests rely on a containerized deployment of the codebase under test.
+The container image for the codebase can be built using the a dockerfile available in the `integration_tests/docker` directory. 
+
+Current conventions prescribe the pattern `Dockerfile-$component` for the name of the dockerfiles, where `$component` might be a short name descriptive of the purpose of the image(e.g. `Dockerfile-confgend` for a image for the confgend codebase).
+
+`make` targets should be defined in the `integration_tests/Makefile` to encapsulate the recipe for building each image required for the tests.
+Those targets should be referenced as pre-requirements in the `test-setup` target.
+
+
+To build the images directly, a docker invocation similar to the following can be run 
+from the `integration_tests` directory:
+```shell
+docker build -f docker/$dockerfile -t wazoplatform/$projectname:local ..
+```
+(the tag given with `-t` must match the image name expected by the corresponding service descriptions in the docker-compose files).
+
+To test that the image is functional:
+```shell
+docker run --rm -it -v $(readlink ..):/usr/local/src/$projectname wazoplatform/$projectname:local
+```
+(note this will mount the project root directory as a volume to provide in-development source code for testing).
+This should start a container from the built image, which should run the component entrypoint(usually a daemon implemented by the codebase).
+
+Once the image is made available locally, the docker-compose configurations should be able to use it and pull any other required images from the relevant registries.
+
+
+## docker-compose
+The wazo test framework used by the test code takes care of controlling `docker-compose` to bring up the services required by the tests.
+The `docker-compose` command can be used directly to debug and manually interact with the test setup.
+
+The docker-compose *stack*(all services and resources managed by docker-compose) is defined through multiple compose files.
+A base `docker-compose.yml` file is combined with override files which can offer different configuration profiles for the test environment.
+At a minimum, a `docker-compose.base.override.yml` would define the settings for a default "baseline" test environment.
+
+To deploy the docker-compose stack for the base environment,
+```shell
+docker-compose -f assets/docker-compose.yml -f assets/docker-compose.base.override.yml up
+```
+Then to stop the services and cleanup active resources managed by docker-compose:
+```shell
+docker-compose -f assets/docker-compose.yml -f assets/docker-compose.base.override.yml down
+```
+To run a specific service and its dependencies:
+```shell
+docker-compose -f assets/docker-compose.yml -f assets/docker-compose.base.override.yml run $service
+```
+To execute a command inside the container environment of a specific service already deployed:
+```shell
+docker-compose -f assets/docker-compose.yml -f assets/docker-compose.base.override.yml exec $service $command
+```
+
+### denv
+[denv](https://github.com/wazo-platform/denv) is a utility to simplify the usage patterns of docker-compose for integration tests.
+
+
+[^1]: https://docs.docker.com/compose/
+[^2]: https://docs.docker.com/
+[^3]: https://docs.pytest.org/en/7.2.x/

--- a/content/uc-doc/contributors/integration-tests.md
+++ b/content/uc-doc/contributors/integration-tests.md
@@ -5,8 +5,8 @@ This document describes the conventional setup for per-component integration tes
 The integration tests rely directly on docker(or an equivalent drop-in) and docker-compose, 
 and assume that functional `docker-compose`[^1] and `docker`[^2] commands are available in the environment.
 
-Required python dependencies are made available in the [test-requirements.txt](./test-requirements.txt) file, 
-which can(and should) be installed into a specific virtual environment.
+Additional python dependencies(including test runners, frameworks and any tool and library used by the tests) are made available in 
+a pip requirements.txt file, to be be installed into a specific virtual environment.
 
 ## Structure
 (As a general guide on conventional project structure, see also [Wazo daemon file structure](https://github.com/wazo-platform/wazo-notebook/blob/master/file-structure.md) 
@@ -27,7 +27,8 @@ tox -e integration
 tox takes care of creating the virtual environment containing the dependencies for the tests.
 
 The `integration_tests/Makefile` should define a target `test-setup` to prepare the test environment(e.g. build docker images),
-and a `test` target to run the tests. Those targets can be used directly, and should be used by the tox `integration` environment.
+and a `test` target to run the tests. 
+Those targets can be used directly, and should be used by the tox `integration` environment.
 To run the tests without tox from the `integration_tests` directory:
 ```shell
 # make test dependencies available in a virtual environment

--- a/content/uc-doc/contributors/integration-tests.md
+++ b/content/uc-doc/contributors/integration-tests.md
@@ -2,26 +2,38 @@ This document describes the conventional setup for per-component integration tes
 
 ## Requirements
 
-The integration tests rely directly on docker(or an equivalent drop-in) and docker-compose,
-and assume that functional [`docker-compose`](https://docs.docker.com/compose/) and [`docker`](https://docs.docker.com/) commands are available in the environment.
+The integration tests rely directly on docker(or an equivalent drop-in) and docker-compose, and
+assume that functional [`docker-compose`](https://docs.docker.com/compose/) and
+[`docker`](https://docs.docker.com/) commands are available in the environment.
 
-Additional python dependencies(including test runners, frameworks and any tool and library used by the tests) are made available in
-a pip requirements.txt file, to be be installed into a specific virtual environment.
+Additional python dependencies(including test runners, frameworks and any tool and library used by
+the tests) are made available in a pip requirements.txt file, to be be installed into a specific
+virtual environment.
 
 ## Structure
 
-(As a general guide on conventional project structure, see also [Wazo daemon file structure](https://github.com/wazo-platform/wazo-notebook/blob/master/file-structure.md)
+(As a general guide on conventional project structure, see also
+[Wazo daemon file structure](https://github.com/wazo-platform/wazo-notebook/blob/master/file-structure.md)
 
-- All files related to integration tests should be present under an `integration_tests` directory directly below a project root directory.
-- `integration_tests/assets` should contain docker-compose yaml files as well as configuration and static assets required for tests at runtime(usually mounted as volumes configured in the compose files).
-- `integration_tests/docker` should contain custom dockerfiles and other files required to build images for the test setup(referenced in compose files).
-- `integration_tests/suite` should contain the actual python tests definitions, including any custom helpers and utilities.
-- `integration_tests/test-requirements.txt` (or a differently named pip requirements file) should contain all python requirements required for the test environment, such as the test runner, and other tools and libraries used by the tests.
-- `integration_tests/Makefile` should exist and define an interface to interact with the test setup using the `make` utility.
+- All files related to integration tests should be present under an `integration_tests` directory
+  directly below a project root directory.
+- `integration_tests/assets` should contain docker-compose yaml files as well as configuration and
+  static assets required for tests at runtime(usually mounted as volumes configured in the compose
+  files).
+- `integration_tests/docker` should contain custom dockerfiles and other files required to build
+  images for the test setup(referenced in compose files).
+- `integration_tests/suite` should contain the actual python tests definitions, including any custom
+  helpers and utilities.
+- `integration_tests/test-requirements.txt` (or a differently named pip requirements file) should
+  contain all python requirements required for the test environment, such as the test runner, and
+  other tools and libraries used by the tests.
+- `integration_tests/Makefile` should exist and define an interface to interact with the test setup
+  using the `make` utility.
 
 ## Running Tests
 
-A tox interface should be available, enabling integration tests to be executed from the project root directory through
+A tox interface should be available, enabling integration tests to be executed from the project root
+directory through
 
 ```shell
 tox -e integration
@@ -29,10 +41,10 @@ tox -e integration
 
 tox takes care of creating the virtual environment containing the dependencies for the tests.
 
-The `integration_tests/Makefile` should define a target `test-setup` to prepare the test environment(e.g. build docker images),
-and a `test` target to run the tests.
-Those targets can be used directly, and should be used by the tox `integration` environment.
-To run the tests without tox from the `integration_tests` directory:
+The `integration_tests/Makefile` should define a target `test-setup` to prepare the test
+environment(e.g. build docker images), and a `test` target to run the tests. Those targets can be
+used directly, and should be used by the tox `integration` environment. To run the tests without tox
+from the `integration_tests` directory:
 
 ```shell
 # make test dependencies available in a virtual environment
@@ -44,7 +56,8 @@ make test
 
 ### pytest
 
-The tests suites usually use [`pytest`](https://docs.pytest.org/en/7.2.x/) as a test runner and framework, which should be made available through the test python requirements file.
+The tests suites usually use [`pytest`](https://docs.pytest.org/en/7.2.x/) as a test runner and
+framework, which should be made available through the test python requirements file.
 
 For example, to run a single test file and all tests contained:
 
@@ -66,22 +79,26 @@ pytest -m 'critical' -k 'pjsip_conf' suite/
 
 ## Docker
 
-The tests rely on a containerized deployment of the codebase under test.
-The container image for the codebase can be built using the a dockerfile available in the `integration_tests/docker` directory.
+The tests rely on a containerized deployment of the codebase under test. The container image for the
+codebase can be built using the a dockerfile available in the `integration_tests/docker` directory.
 
-Current conventions prescribe the pattern `Dockerfile-$component` for the name of the dockerfiles, where `$component` might be a short name descriptive of the purpose of the image(e.g. `Dockerfile-confgend` for a image for the confgend codebase).
+Current conventions prescribe the pattern `Dockerfile-$component` for the name of the dockerfiles,
+where `$component` might be a short name descriptive of the purpose of the image(e.g.
+`Dockerfile-confgend` for a image for the confgend codebase).
 
-`make` targets should be defined in the `integration_tests/Makefile` to encapsulate the recipe for building each image required for the tests.
-Those targets should be referenced as pre-requirements in the `test-setup` target.
+`make` targets should be defined in the `integration_tests/Makefile` to encapsulate the recipe for
+building each image required for the tests. Those targets should be referenced as pre-requirements
+in the `test-setup` target.
 
-To build the images directly, a docker invocation similar to the following can be run
-from the `integration_tests` directory:
+To build the images directly, a docker invocation similar to the following can be run from the
+`integration_tests` directory:
 
 ```shell
 docker build -f docker/$dockerfile -t wazoplatform/$projectname:local ..
 ```
 
-(the tag given with `-t` must match the image name expected by the corresponding service descriptions in the docker-compose files).
+(the tag given with `-t` must match the image name expected by the corresponding service
+descriptions in the docker-compose files).
 
 To test that the image is functional:
 
@@ -89,19 +106,24 @@ To test that the image is functional:
 docker run --rm -it -v $(readlink ..):/usr/local/src/$projectname wazoplatform/$projectname:local
 ```
 
-**Note**: This will mount the project root directory as a volume to provide in-development source code for testing)
-This should start a container from the built image, which should run the component entrypoint(usually a daemon implemented by the codebase).
+**Note**: This will mount the project root directory as a volume to provide in-development source
+code for testing) This should start a container from the built image, which should run the component
+entrypoint(usually a daemon implemented by the codebase).
 
-Once the image is made available locally, the docker-compose configurations should be able to use it and pull any other required images from the relevant registries.
+Once the image is made available locally, the docker-compose configurations should be able to use it
+and pull any other required images from the relevant registries.
 
 ## docker-compose
 
-The wazo test framework used by the test code takes care of controlling `docker-compose` to bring up the services required by the tests.
-The `docker-compose` command can be used directly to debug and manually interact with the test setup.
+The wazo test framework used by the test code takes care of controlling `docker-compose` to bring up
+the services required by the tests. The `docker-compose` command can be used directly to debug and
+manually interact with the test setup.
 
-The docker-compose _stack_(all services and resources managed by docker-compose) is defined through multiple compose files.
-A base `docker-compose.yml` file is combined with override files which can offer different configuration profiles for the test environment.
-At a minimum, a `docker-compose.base.override.yml` would define the settings for a default "baseline" test environment.
+The docker-compose _stack_(all services and resources managed by docker-compose) is defined through
+multiple compose files. A base `docker-compose.yml` file is combined with override files which can
+offer different configuration profiles for the test environment. At a minimum, a
+`docker-compose.base.override.yml` would define the settings for a default "baseline" test
+environment.
 
 To deploy the docker-compose stack for the base environment,
 
@@ -129,4 +151,5 @@ docker-compose -f assets/docker-compose.yml -f assets/docker-compose.base.overri
 
 ### denv
 
-[denv](https://github.com/wazo-platform/denv) is a utility to simplify the usage patterns of docker-compose for integration tests.
+[denv](https://github.com/wazo-platform/denv) is a utility to simplify the usage patterns of
+docker-compose for integration tests.


### PR DESCRIPTION
Adapted from document written in context of wazo-confgend and deemed generally useful.

* The new document is placed in [ uc-doc/contributors](/content/uc-doc/contributors) . Would it be better located in [contribute](/content/contribute)?
* As there are already multiple existing sections describing integration tests, there's is a danger of inconsistency and drift. I added a reference to the new document in existing sections. As the new document includes information available in those existing sections, perhaps the content of those sections should be replaced with the link to the new document to avoid redundancy and inconsistency.