### PR TITLE
tests: upgrade puppeteer container

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,9 +1,11 @@
-FROM alekzonder/puppeteer
+FROM satantime/puppeteer-node:16
+
+RUN mkdir /app
 
 COPY ./package.json /app
-#COPY ./yarn.lock /app
+COPY ./yarn.lock /app
 
 WORKDIR /app
 
 # Install node dependencies
-RUN yarn install
+RUN yarn install --frozen-lockfile


### PR DESCRIPTION
Why:

* The current one is based on Debian 9 Stretch, which is too old and
  cause certificate verification issues with newer CA certs.
