### PR TITLE
Pull request for fix-asterisk-links

### DIFF
--- a/content/amid/description.md
+++ b/content/amid/description.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-A daemon for interacting with [Asterisk's AMI](https://wiki.asterisk.org/wiki/pages/viewpage.action?pageId=4817239) :
+A daemon for interacting with [Asterisk's AMI](https://docs.asterisk.org/Configuration/Interfaces/Asterisk-Manager-Interface-AMI) :
 
 * forward AMI events to RabbitMQ ;
 * expose HTTP JSON interface for AMI actions.

--- a/content/amid/description.md
+++ b/content/amid/description.md
@@ -4,8 +4,8 @@
 
 A daemon for interacting with [Asterisk's AMI](https://docs.asterisk.org/Configuration/Interfaces/Asterisk-Manager-Interface-AMI) :
 
-* forward AMI events to RabbitMQ ;
-* expose HTTP JSON interface for AMI actions.
+- forward AMI events to RabbitMQ ;
+- expose HTTP JSON interface for AMI actions.
 
 Once a user is authenticated against Wazo platform, he can query the `amid` service to receive `AMI` events from Asterisk and push `AMI` command to it.
 
@@ -21,5 +21,5 @@ The REST API for wazo-ami is available [here](../api/amid.html)
 
 ## Related
 
-* [wazo-amid](https://github.com/wazo-platform/wazo-amid)
-* [wazo-amid-client](https://github.com/wazo-platform/wazo-amid-client)
+- [wazo-amid](https://github.com/wazo-platform/wazo-amid)
+- [wazo-amid-client](https://github.com/wazo-platform/wazo-amid-client)

--- a/content/blog/pjsip-multi-tenant.md
+++ b/content/blog/pjsip-multi-tenant.md
@@ -28,7 +28,6 @@ as possible.
 In this article we will look into the process of making this new API multi
 tenant.
 
-
 # Differences Between `chan_sip` and `chan_pjsip`
 
 `chan_sip` is the old channel driver that has been in Asterisk for ages to handle
@@ -45,7 +44,6 @@ used to be a single section for a peer in `sip.conf` is now multiple sections in
 `chan_sip` also accepted a `general` section that could be used to set default
 values for the whole channel driver.
 
-
 # How Wazo Platform Migrated from `chan_sip` to `chan_pjsip`
 
 To be able to move quickly from `chan_sip` to `chan_pjsip`, we chose to use a
@@ -55,12 +53,11 @@ script that is available in the Asterisk source code. This solution was
 sufficient to get us started but we have not been able to leverage the full
 power of the new SIP channel driver.
 
-
 # A Multi Tenant SIP Configuration
 
 The current SIP configuration is not completely multi tenant. What this means is
 that there is still a SIP general configuration that is shared by all SIP
-endpoints, lines and trunks. This general configuration is applied to *all*
+endpoints, lines and trunks. This general configuration is applied to _all_
 tenants of a given engine. The lines and trunks themselves are multi tenant. To
 make matters worse, the old API did not support configuration templates. So a
 tenant A that wants a different configuration from the general configuration of
@@ -80,7 +77,7 @@ password. All other configuration options can be inherited from the general
 configuration; WebRTC configuration and user preferences configuration for
 example.
 
-![Configuration Example](../../images/blog/pjsip-multi-tenant/pjsip_template.png "Template Hierarchy Example")
+![Configuration Example](../../images/blog/pjsip-multi-tenant/pjsip_template.png 'Template Hierarchy Example')
 
 In this example we have three lines owned by two users. Each line inherits from
 the user's preference template and from the SIP or WebRTC template. The SIP and
@@ -92,7 +89,6 @@ configuration and will be able to manage the SIP configuration of all of its
 endpoints independently from the others without duplicating the configuration
 for all of its endpoints.
 
-
 # Reloading
 
 Another problem of the `chan_sip` channel driver and `chan_pjsip` with our current
@@ -102,7 +98,6 @@ The new API will leverage a configuration system named
 each configuration to be updated individually. Every time a configuration change
 is done, Wazo Platform will be able to update the modified sections of the configuration
 only for the impacted resources instead of reloading the entire channel driver.
-
 
 # Migrating to the New API
 
@@ -115,7 +110,6 @@ wazo-ui.
 At the moment, there is no plan to keep the old and new API working together. If
 you do use the SIP configuration API, get in touch with us on the
 [forum](https://wazo-platform.discourse.group/t/blog-a-multi-tenant-api-for-pjsip/248)
-
 
 # Conclusion
 

--- a/content/blog/pjsip-multi-tenant.md
+++ b/content/blog/pjsip-multi-tenant.md
@@ -20,7 +20,7 @@ configuration to a `chan_pjsip` one.
 The translation system we are using at the moment does not deliver all the
 values we could get from a properly configured `chan_pjsip`. Moreover, the
 standard format of the `pjsip.conf` file is hard to override without using the
-[PJSIP Wizard](https://wiki.asterisk.org/wiki/display/AST/PJSIP+Configuration+Wizard).
+[PJSIP Wizard](https://docs.asterisk.org/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/PJSIP-Configuration-Wizard).
 
 We chose to use this change in API to make the SIP configuration as multi tenant
 as possible.
@@ -98,7 +98,7 @@ for all of its endpoints.
 Another problem of the `chan_sip` channel driver and `chan_pjsip` with our current
 implementation is the need to reload the configuration for each modification.
 The new API will leverage a configuration system named
-[Sorcery](https://wiki.asterisk.org/wiki/display/AST/Sorcery). It will allow
+[Sorcery](https://docs.asterisk.org/Fundamentals/Asterisk-Configuration/Sorcery). It will allow
 each configuration to be updated individually. Every time a configuration change
 is done, Wazo Platform will be able to update the modified sections of the configuration
 only for the impacted resources instead of reloading the entire channel driver.

--- a/content/uc-doc/administration/interconnections/two_wazo.md
+++ b/content/uc-doc/administration/interconnections/two_wazo.md
@@ -75,7 +75,7 @@ The most useful special characters to match extensions are:
 - `X`: will match only one character
 
 You can find more details about pattern matching in Asterisk (hence in Wazo) on
-[the Asterisk wiki](https://wiki.asterisk.org/wiki/display/AST/Pattern+Matching).
+[the Asterisk wiki](https://docs.asterisk.org/Configuration/Dialplan/Pattern-Matching).
 
 ## Set the incoming calls
 

--- a/content/uc-doc/administration/interconnections/wazo_with_voip_provider.md
+++ b/content/uc-doc/administration/interconnections/wazo_with_voip_provider.md
@@ -60,7 +60,7 @@ The most useful special characters to match extensions are:
 - `X`: will match only one character
 
 You can find more details about pattern matching in Asterisk (hence in Wazo) on
-[the Asterisk wiki](https://wiki.asterisk.org/wiki/display/AST/Pattern+Matching).
+[the Asterisk wiki](https://docs.asterisk.org/Configuration/Dialplan/Pattern-Matching).
 
 ## Set the incoming calls {#voip-provider-incall}
 

--- a/content/uc-doc/administration/nat.md
+++ b/content/uc-doc/administration/nat.md
@@ -55,4 +55,4 @@ work in all situations:
 ## References
 
 If you need more details, you may find an answer in the
-[Asterisk SIP documentation about NAT](https://wiki.asterisk.org/wiki/display/AST/Configuring+res_pjsip+to+work+through+NAT)
+[Asterisk SIP documentation about NAT](https://docs.asterisk.org/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/Configuring-res_pjsip-to-work-through-NAT)

--- a/content/uc-doc/api_sdk/subroutine.md
+++ b/content/uc-doc/api_sdk/subroutine.md
@@ -180,9 +180,8 @@ Some of the Wazo variables can be used and modified in subroutines (non exhausti
 - `WAZO_GROUPOPTIONS`: the value is a list of options to be passed to the Queue application, e.g.
   `hHtT`. This variable is only available in group subroutines.
 - `WAZO_INTERFACE`: the value is the Technology/Resource pairs that are used as the first argument
-  of the
-  [Dial application](https://docs.asterisk.org/Configuration/Applications/Dial-Application). This
-  variable is only available in the user subroutines.
+  of the [Dial application](https://docs.asterisk.org/Configuration/Applications/Dial-Application).
+  This variable is only available in the user subroutines.
 - `WAZO_MOBILEPHONENUMBER`: the value is the phone number of a user, as set in the web interface.
   This variable is only available in user subroutines.
 - `WAZO_QUEUENAME`: the value is the name of the queue being called. This variable is only available

--- a/content/uc-doc/api_sdk/subroutine.md
+++ b/content/uc-doc/api_sdk/subroutine.md
@@ -181,7 +181,7 @@ Some of the Wazo variables can be used and modified in subroutines (non exhausti
   `hHtT`. This variable is only available in group subroutines.
 - `WAZO_INTERFACE`: the value is the Technology/Resource pairs that are used as the first argument
   of the
-  [Dial application](https://wiki.asterisk.org/wiki/display/AST/Asterisk+13+Application_Dial). This
+  [Dial application](https://docs.asterisk.org/Configuration/Applications/Dial-Application). This
   variable is only available in the user subroutines.
 - `WAZO_MOBILEPHONENUMBER`: the value is the phone number of a user, as set in the web interface.
   This variable is only available in user subroutines.

--- a/content/uc-doc/contributors/debug_asterisk.md
+++ b/content/uc-doc/contributors/debug_asterisk.md
@@ -523,5 +523,4 @@ Running asterisk under valgrind takes a lots of extra memory, so make sure you h
 
 ## External links {#external-links}
 
-- <https://wiki.asterisk.org/wiki/display/AST/Debugging>
-- <https://wiki.asterisk.org/wiki/display/AST/Valgrind>
+- <https://docs.asterisk.org/Development/Debugging>

--- a/content/uc-doc/upgrade/upgrade_notes.md
+++ b/content/uc-doc/upgrade/upgrade_notes.md
@@ -587,7 +587,7 @@ for more information.
 - Call recording will now play a beep when the recording starts and end. This behavior can be
   modified in `/etc/xivo/asterisk/xivo_globals.conf` by modifying the `WAZO_MIXMONITOR_OPTIONS`. See
   the
-  [Asterisk documentation](https://wiki.asterisk.org/wiki/display/AST/Asterisk+18+Application_MixMonitor)
+  [Asterisk documentation](https://docs.asterisk.org/Asterisk_18_Documentation/API_Documentation/Dialplan_Applications/MixMonitor)
   for available options.
 - The group resource is now identified by a UUID instead of sequential ID. The API using sequential
   ID will keep working for a while. Policies with permissions for a specific group will have to be

--- a/content/uc-doc/upgrade/upgrade_notes_details/18-12/asterisk_16.md
+++ b/content/uc-doc/upgrade/upgrade_notes_details/18-12/asterisk_16.md
@@ -20,5 +20,5 @@ your `cel.conf` or `cel.d/*` you will have to remove that line from your configu
 
 You can see the complete list of changes from the Asterisk website:
 
-- <https://wiki.asterisk.org/wiki/display/AST/Upgrading+to+Asterisk+16>
+- <https://docs.asterisk.org/Asterisk_16_Documentation/Upgrading>
 - <https://github.com/asterisk/asterisk/blob/16/CHANGES>


### PR DESCRIPTION
## fix broken wiki.asterisk links

why: wiki links are redirect to the home page of new docs.asterisk.org

## fix linters