### PR TITLE
tests: exclude gigaset wiki links

### DIFF
--- a/tests/src/404.js
+++ b/tests/src/404.js
@@ -46,6 +46,11 @@ function isUrlWhitelisted(url, fromUrl) {
     return true;
   }
 
+  // Gigaset wiki links are flaky
+  if (url.indexOf('https://teamwork.gigaset.com/gigawiki') !== -1) {
+    return true;
+  }
+
   return false;
 }
 


### PR DESCRIPTION
Why:

* Links are slow to load and reach 30s timeout