### PR TITLE
contributors: python typing: remove suggestion for follow_imports

### DIFF
--- a/content/uc-doc/contributors/typing.md
+++ b/content/uc-doc/contributors/typing.md
@@ -444,7 +444,6 @@ python_version = "3.10"
 show_error_codes = true
 check_untyped_defs = true
 warn_unused_configs = true
-follow_imports = "skip"
 ignore_missing_imports = true
 ```
 


### PR DESCRIPTION
Why:

* follow_imports breaks pre-commit typing analysis in some cases