### PR TITLE
update certbot link with os=snap

### DIFF
--- a/content/uc-doc/system/https_certificate.md
+++ b/content/uc-doc/system/https_certificate.md
@@ -39,7 +39,7 @@ systemctl restart nginx
 ```
 
 For more details, see the official
-[Certbot documentation](https://certbot.eff.org/instructions?ws=nginx&os=debianbuster).
+[Certbot documentation](https://certbot.eff.org/instructions?ws=nginx&os=snap).
 
 ## Use your own certificate
 


### PR DESCRIPTION
why: debianbuster already redirect to snap