### PR TITLE
Make redirects works

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,6 +7,7 @@ const path = require('path');
  */
 
 module.exports = {
+  trailingSlash: 'always',
   plugins: [
     'gatsby-plugin-react-helmet',
     {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -538,7 +538,7 @@ exports.createPages = async ({ graphql, actions: { createPage, createRedirect } 
   // ---------
   console.log('Generating 301 redirects');
   const generate301 = (fromPath, toPath) => {
-    const enhancedFromPath = fromPath.endsWith('.html') ? fromPath : fromPath.endsWith('/') ? fromPath : `${fromPath}/`
+    const enhancedFromPath = fromPath.endsWith('.html') || fromPath.endsWith('/') ? fromPath : `${fromPath}/`
 
     createRedirect({
       fromPath: enhancedFromPath,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -578,7 +578,6 @@ exports.createPages = async ({ graphql, actions: { createPage, createRedirect } 
   generate301('/uc-doc/system/wazo-confgend/introduction', '/uc-doc/system/wazo-confgend');
   generate301('/uc-doc/system/wazo-dird/introduction', '/uc-doc/system/wazo-dird');
   generate301('/uc-doc/introduction', '/uc-doc');
-  generate301('/uc-doc/attribution', '/uc-doc');
   generate301('/uc-doc/changelog', '/uc-doc');
   generate301('/uc-doc/upgrade/old_upgrade_notes', '/uc-doc/upgrade/archives/upgrade_notes');
   generate301('/uc-doc/upgrade/upgrade_from_wazo_18_03', '/uc-doc/upgrade/archives/upgrade_from_wazo_18_03');

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-plugin-styled-components": "^2.0.7",
     "btoa": "^1.2.1",
     "gatsby": "^4.18.2",
+    "gatsby-plugin-meta-redirect": "^1.1.1",
     "gatsby-plugin-react-helmet": "^5.18.0",
     "gatsby-plugin-styled-components": "^5.18.0",
     "gatsby-remark-autolink-headers": "^5.18.1",

--- a/website/redirects.ts
+++ b/website/redirects.ts
@@ -61,7 +61,7 @@ const REDIRECTS: Options['redirects'] = [
     to: '/uc-doc/system/wazo-dird',
   },
   {
-    from: ['/uc-doc/introduction', '/uc-doc/attribution', '/uc-doc/changelog'],
+    from: ['/uc-doc/introduction', '/uc-doc/changelog'],
     to: '/uc-doc',
   },
   {

--- a/website/uc-doc/attribution.md
+++ b/website/uc-doc/attribution.md
@@ -1,0 +1,9 @@
+---
+title: Attribution Notice
+sidebar_class_name: hidden
+---
+
+The major part of this documentation has been copied (2016-11-25) from the XiVO documentation
+(originally hosted at `http://documentation.xivo.io`). That documentation was licensed under the
+[Create Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/)
+and was Copyright 2012-2016 Avencall

--- a/website/uc-doc/index.md
+++ b/website/uc-doc/index.md
@@ -26,9 +26,4 @@ In November 2016, Proformatique Inc. was shut down and the development team
 [forked XiVO to create Wazo](/blog/introducing-wazo). Its first release, Wazo 16.16, was released in
 December 2016.
 
-:::note[Attribution Notice]
-The major part of this documentation has been copied (2016-11-25) from the
-XiVO documentation (originally hosted at `http://documentation.xivo.io`). That documentation was licensed
-under the [Create Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/)
-and was Copyright 2012-2016 Avencall
-:::
+See [Attribution Notice](/uc-doc/attribution/)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5456,7 +5456,7 @@ fs-extra@^10.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^7.0.1:
+fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -5639,6 +5639,13 @@ gatsby-parcel-config@0.15.1:
     "@parcel/runtime-js" "2.6.2"
     "@parcel/transformer-js" "2.6.2"
     "@parcel/transformer-json" "2.6.2"
+
+gatsby-plugin-meta-redirect@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-meta-redirect/-/gatsby-plugin-meta-redirect-1.1.1.tgz#058e8e53edff38dc44d3bb6153109d01c910f863"
+  integrity sha512-Oc4qgU3SlDUM9qoxIMKO+re2bdMs3/a2KXrfL65gb8XMLsHylBbveWtXZRhgjd2QDL/49RX4S9SEykuadRju2w==
+  dependencies:
+    fs-extra "^7.0.0"
 
 gatsby-plugin-page-creator@^4.24.1:
   version "4.24.1"


### PR DESCRIPTION
# Summary of changes

- Since we upgrade to gatsby v4, redirect were broken. Use adapter to make it work
- Bring back `/uc-doc/attribution` page