### PR TITLE
docker: added alternative docker assets for beta website

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ beta/builder:
 	$(DOCKER_COMPOSE_BETA) build
 
 beta/develop: beta/builder
-	$(DOCKER_COMPOSE_BETA) run --rm --service-ports doc bash -c "yarn install && yarn docusaurus start $(ARGS)"
+	$(DOCKER_COMPOSE_BETA) run --rm --service-ports doc bash -c "yarn install && yarn docusaurus start -h 0.0.0.0 $(ARGS)"
 
 check-format-uc-doc:
 	docker compose run --no-TTY doc yarn check-format:uc-doc

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,13 @@ builder:
 develop: builder
 	docker compose run --service-ports doc env $(ENV) yarn develop -H 0.0.0.0
 
+DOCKER_COMPOSE_BETA=docker compose -f docker-compose.yml -f docker-compose.beta.yml
+beta/builder:
+	$(DOCKER_COMPOSE_BETA) build
+
+beta/develop: beta/builder
+	$(DOCKER_COMPOSE_BETA) run --rm --service-ports doc bash -c "yarn install && yarn docusaurus start $(ARGS)"
+
 check-format-uc-doc:
 	docker compose run --no-TTY doc yarn check-format:uc-doc
 

--- a/beta.Dockerfile
+++ b/beta.Dockerfile
@@ -1,0 +1,21 @@
+# From https://github.com/docker-library/docs/blob/master/eclipse-temurin/README.md#using-a-different-base-image
+FROM node:20.15.0-bullseye-slim AS build-node
+ENV LANG=en_US.UTF-8
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+RUN apt-get update && apt-get install -y git graphviz wget fonts-dejavu fontconfig make
+
+ENV PLANTUML_VERSION=1.2022.6
+RUN wget "https://github.com/plantuml/plantuml/releases/download/v$PLANTUML_VERSION/plantuml-$PLANTUML_VERSION.jar" -O $JAVA_HOME/lib/plantuml.jar
+
+# Test plantuml can be loaded
+RUN java -Djava.awt.headless=true -jar $JAVA_HOME/lib/plantuml.jar -version
+
+WORKDIR /app
+
+COPY ./website/package.json /app/package.json
+COPY ./website/yarn.lock /app/yarn.lock
+
+RUN corepack enable && yarn install

--- a/docker-compose.beta.yml
+++ b/docker-compose.beta.yml
@@ -1,0 +1,18 @@
+services:
+  # Use to build project
+  doc:
+    build:
+      dockerfile: beta.Dockerfile
+    ports:
+      - '3000:3000'
+    working_dir: /app/website
+    volumes:
+      - ./src:/app/src:ro
+      - ./scripts:/app/scripts:ro
+      - ./website:/app/website
+      - ./static:/app/website/static:ro
+      - ./.prettierrc:/app/.prettierrc:ro
+      - ./.prettierignore:/app/.prettierignore:ro
+      - ./config.js:/app/config.js:ro
+      - ./tests:/app/tests:ro
+      - ./Makefile:/app/Makefile:ro


### PR DESCRIPTION
Need separate dockerfile, docker-compose file and Makefile targets to develop on the beta website using docker.

- dockerfile with node version and yarn setup for docusaurus website
- docker-compose file with appropriate volume mounts and build parameters
- `make beta/develop` and `make beta/builder` make targets