### PR TITLE
fix: 404 and wrong redirect

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -565,7 +565,7 @@ exports.createPages = async ({ graphql, actions: { createPage, createRedirect } 
   generate301('/uc-doc/administration/contact_directories/general', '/uc-doc/administration/contact_directories');
   generate301('/uc-doc/administration/interconnections/introduction', '/uc-doc/administration/interconnections');
   generate301('/uc-doc/administration/provisioning/introduction', '/uc-doc/administration/provisioning');
-  generate301('/uc-doc/administration/users', '/uc-doc/administration');
+  generate301('/uc-doc/administration/users/users', '/uc-doc/administration/users');
   generate301('/uc-doc/api_sdk/mobile/push_notification', '/uc-doc/api_sdk/mobile_push_notification');
   generate301('/uc-doc/api_sdk/mobile', '/uc-doc/api_sdk/mobile_push_notification');
   generate301('/uc-doc/contact_center/introduction', '/uc-doc/contact_center');

--- a/src/component/home/index.js
+++ b/src/component/home/index.js
@@ -13,7 +13,7 @@ const Page = () => (
         <img src={LogoSquare} alt="Wazo Platform" id="wazo-platform" />
         <p className="intro">An Open Source project to build your own IP&nbsp;telecom platform</p>
         <div className="btns">
-          <Link className="btn btn-cta-secondary" to="uc-doc/installation/install-system">
+          <Link className="btn btn-cta-secondary" to="uc-doc/installation">
             Install
           </Link>
           <Link className="btn btn-cta-primary" to="documentation">

--- a/website/redirects.ts
+++ b/website/redirects.ts
@@ -14,8 +14,8 @@ const REDIRECTS: Options['redirects'] = [
     to: '/uc-doc/administration/provisioning',
   },
   {
-    from: '/uc-doc/administration/users',
-    to: '/uc-doc/administration',
+    from: '/uc-doc/administration/users/users',
+    to: '/uc-doc/administration/users',
   },
   {
     from: [

--- a/website/uc-doc/administration/index.md
+++ b/website/uc-doc/administration/index.md
@@ -32,7 +32,7 @@ All configurations are done via the [`wazo-confd` REST API](/documentation/api/c
     { text: 'SCCP', href: '/uc-doc/administration/sccp' },
     { text: 'Schedules', href: '/uc-doc/administration/schedules' },
     { text: 'Sound Files', href: '/uc-doc/administration/sound_files' },
-    { text: 'Users', href: '/uc-doc/administration/users/users' },
+    { text: 'Users', href: '/uc-doc/administration/users' },
     { text: 'Voicemails', href: '/uc-doc/administration/voicemails' },
     { text: 'SIP Templates', href: '/uc-doc/administration/sip_templates' },
     { text: 'Call Policy', href: '/uc-doc/administration/call_policy' },


### PR DESCRIPTION
## Summary of changes

- Typo on `/users/users` redirect
- Fix remaining 404 links