### PR TITLE
Pull request for WAZO-3544-remove-swagger-doc

### DIFF
--- a/website/uc-doc/api_sdk/rest_api/troubleshooting.md
+++ b/website/uc-doc/api_sdk/rest_api/troubleshooting.md
@@ -4,14 +4,18 @@ title: Troubleshooting
 
 Here is a list of common problems you can encounter with Wazo REST APIs.
 
-## Swagger UI: Can't read from server...
+## API Console: Failed to load API definition...
 
 ### Problem
 
-When trying to access Swagger UI via `http://wazo/api`, I get:
+When trying to access to the API Console via `https://wazo-platform.org/documentation`, I get:
 
 ```markdown
-Can't read from server. It may not have the appropriate access-control-origin settings.
+Failed to load API definition.
+
+Errors Fetch error Failed to fetch https://<stack_ip>/api/confd/1.1/api/api.yml Fetch error Possible
+cross-origin (CORS) issue? The URL origin (https://<stack_ip>) does not match the page
+(https://wazo-platform.org). Check the server returns the correct 'Access-Control-Allow-\*' headers.
 ```
 
 ### Answer
@@ -24,8 +28,8 @@ commonly:
 
 What you can do:
 
-- check that the Swagger API spec is accessible: when choosing an API in the Swagger menu,
-  copy-paste the URL of the top text box ending with `api.yml` into your browser.
+- check that the OpenAPI spec is accessible: when choosing an API Console, copy-paste the both parts
+  (IP + .../api.yml) of the URL of the top text boxes into your browser.
 - check the HTTP requests/answers in your browser debugging tools
 - check that the daemon is running: in a console, type: `wazo-service status`
 - check the log files of the daemon in `/var/log/<daemon>.log` (see also:

--- a/website/uc-doc/system/nginx.md
+++ b/website/uc-doc/system/nginx.md
@@ -13,7 +13,6 @@ services to be used:
 - The telephony service interface (wazo-calld)
 - The directory service (wazo-dird)
 - The AMI HTTP interface (wazo-amid)
-- API documentation (xivo-swagger-doc)
 - The websocket interface (wazo-websocketd)
 - Asterisk WebSocket (xivo-config)
 

--- a/website/uc-doc/upgrade/upgrade_notes.md
+++ b/website/uc-doc/upgrade/upgrade_notes.md
@@ -3,6 +3,16 @@ title: Upgrade notes
 sidebar_position: 1
 ---
 
+## 25.01 {#25-01}
+
+- The embedded API documentation (`https://<wazo-ip>/api`) has been removed. You can access the same
+  documentation via the [API Console](https://wazo-platform.org/documentation) on the Wazo platform
+  website, using your `<wazo-ip>` for local API access.
+
+Consult the
+[25.01 Tickets](https://wazo-dev.atlassian.net/issues/?jql=project%20%3D%20WAZO%20AND%20fixVersion%20%3D%2025.01)
+for more information.
+
 ## 24.17 {#24-17}
 
 Consult the


### PR DESCRIPTION
## Replace embedded swagger by wazo-platform.org swagger


## upgrade: remove embedded API Documentation (swagger)