### PR TITLE
developers.wazo.io: adds a Jenkinsfile for the pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,101 @@
+def buildSSHRemote(params) {
+  def remote = [:]
+  remote.name = params.host
+  remote.host = params.host
+  remote.knownHosts = '/home/admin/.ssh/known_hosts'
+  remote.allowAnyHosts = params.allowAnyHosts
+  remote.user = env.SSH_CREDS_USR
+  if (params.withPassword) {
+    remote.password = env.SSH_CREDS_PSW
+  } else {
+    remote.identityFile = env.SSH_CREDS
+  }
+  remote.logLevel = 'SEVERE'  // Setting any logLevel will remove host from public log
+  return remote
+}
+
+def webserver_community = 'webserver.wazo.community'
+
+pipeline {
+
+  triggers {
+    pollSCM 'H 0 * * *'
+  }
+
+  options {
+    timestamps()
+  }
+
+  agent {
+    label 'general-medium'
+  }
+  environment {
+    CONFIG_FILE_PATH = credentials('wazo-doc-tools-credentials')
+    SSH_CREDS = credentials('ssh-private-key-for-webserver')
+  }
+
+  stages {
+    stage ("Cleanup") {
+      steps {
+        sh """
+          set -xe
+          cp ${CONFIG_FILE_PATH} config.js
+
+          make ENV=CORPORATE=1 builder
+          make ENV=CORPORATE=1 build
+
+          sudo curl -L -o /usr/local/bin/docker-compose https://github.com/docker/compose/releases/download/v2.39.2/docker-compose-linux-x86_64
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose down
+          rm config.js
+        """
+      }
+    }
+    stage ("Prepare") {
+      steps {
+        sshagent(credentials: ['ssh-private-key-for-webserver']) {
+          sh """
+            set -xe
+            cat > ${WORKSPACE}/webserver.wazo.community.known_hosts << EOF
+webserver.wazo.community ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIezVt71SDQZ2KsL7yzjGqbvjyt95HEIi0TpxXoaZywf
+EOF
+
+            rsync \
+              -rlD --delete \
+              -e "ssh -o UserKnownHostsFile=${WORKSPACE}/webserver.wazo.community.known_hosts" \
+              public/ root@webserver.wazo.community:/tmp/developers/
+          """
+        }
+      }
+    }
+
+    stage ("Deploy") {
+      steps {
+        script {
+          def remote_webserver_community = buildSSHRemote(host: webserver_community, allowAnyHosts: true)
+          sshCommand(
+            remote: remote_webserver_community,
+            command: '''
+              set -euo pipefail
+
+              # If we use rsync directly and rsync fails with "Broken pipe", then it
+              # will break the website installation.
+              # To prevent that, rsync into temporary directory, then mv 
+              # the new website install.
+
+              mv -T /tmp/developers /var/www/developers-new
+              mv -T /var/www/developers /var/www/developers-old
+              mv -T /var/www/developers-new /var/www/developers
+              rm -rf /var/www/developers-old
+          '''
+            )
+        }
+      }
+    }
+  }
+  post {
+    always {
+      cleanWS()
+    }
+  }
+}


### PR DESCRIPTION
**why**
The website deployment is handled via a manual steps Jenkins job. The maintenance will be better with a Jenkinsfile
Plus, the pipeline is ran from an EC2 runner


https://jenkins.wazo.community/job/developers.wazo.io-with-jenkisfile/