### PR TITLE
tests: adds exceptions for hashicorp urls

### DIFF
--- a/tests/src/404.js
+++ b/tests/src/404.js
@@ -76,6 +76,11 @@ function isUrlWhitelisted(url, fromUrl) {
     return true;
   }
 
+  // hashicorp.com responds status 429 when crawling multiple URLs in a row
+  if (url.indexOf('hashicorp.com') !== -1) {
+    return true;
+  }
+
   return false;
 }
 


### PR DESCRIPTION
**why**
One of the test checks that external urls do not respond 404. 
Recently hashicorp.com links started to answer a 429 status code to our test, making it fail