### PR TITLE
pipeline: remove post action

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,9 +93,4 @@ EOF
       }
     }
   }
-  post {
-    always {
-      cleanWS()
-    }
-  }
 }


### PR DESCRIPTION
**why**
It relies on cleanWS, a DSL on Workspace Cleanup plugin. Not an issue as :
- the pipeline runs on an ephemeral runner
- the pipeline is not ran frequently