### PR TITLE
[ITEM-205] uc-doc: remove calllistening func_key destination

### DIFF
--- a/website/uc-doc/api_sdk/rest_api/confd/func_keys.md
+++ b/website/uc-doc/api_sdk/rest_api/confd/func_keys.md
@@ -180,7 +180,6 @@ Currently supported services:
 - `incallfilter`: Incoming call filtering
 - `enablednd`: Enable "Do not disturb" mode
 - `pickup`: Group Interception
-- `calllistening`: Listen to online calls
 - `directoryaccess`: Directory access
 - `fwdundoall`: Disable all forwaring
 - `enablevm`: Enable Voicemail


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that removes the deprecated/unsupported `calllistening` service from the function key destination list; no runtime behavior is affected.
> 
> **Overview**
> Updates `website/uc-doc/api_sdk/rest_api/confd/func_keys.md` to **remove the `calllistening` entry** from the list of supported `service` destinations for function keys, aligning the REST API docs with current supported values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce5aed0682385a28d2e60312cf9c64d8199c5061. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->