### PR TITLE
TASK-248-agentd-cli-refactor

### DIFF
--- a/website/uc-doc/upgrade/upgrade_notes.md
+++ b/website/uc-doc/upgrade/upgrade_notes.md
@@ -3,6 +3,11 @@ title: Upgrade notes
 sidebar_position: 1
 ---
 
+## 26.05 {#26-05}
+
+- The `-c` flag of `wazo-agentd-cli` is no longer needed and is deprecated. It will be removed in a
+  future version.
+
 ## 26.03 {#26-03}
 
 Consult the


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change; no runtime code or behavior is modified.
> 
> **Overview**
> Adds a new `26.05` entry to the upgrade notes documenting that the `-c` flag for `wazo-agentd-cli` is no longer required, is now deprecated, and will be removed in a future release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b01c2654768b6793c87f026da75b59bc64c17a6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->