### PR TITLE
upgrade: Add upgrade note for recording

### DIFF
--- a/website/uc-doc/upgrade/upgrade_notes.md
+++ b/website/uc-doc/upgrade/upgrade_notes.md
@@ -3,6 +3,11 @@ title: Upgrade notes
 sidebar_position: 1
 ---
 
+## 26.05 {#26-05}
+
+- **Groups & Queues recording.** `dtmf_record_toggle` has to be set to `True` for groups
+  and queue to allow for automatic recording on the answerer's side.
+
 ## 26.03 {#26-03}
 
 Consult the


### PR DESCRIPTION
WP-2020

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; no runtime, security, or data-handling logic is modified.
> 
> **Overview**
> Adds a new **26.05** entry to `website/uc-doc/upgrade/upgrade_notes.md` documenting that `dtmf_record_toggle` must be set to `True` on groups/queues to enable automatic recording on the answerer side.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d95c80f015bc245e2f686ac37a644d0204d7674a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->