### PR TITLE
upgrade_notes: add new agent login to queues behaviour when no previously logged queues

### DIFF
--- a/website/uc-doc/upgrade/upgrade_notes.md
+++ b/website/uc-doc/upgrade/upgrade_notes.md
@@ -7,6 +7,8 @@ sidebar_position: 1
 
 - The `-c` flag of `wazo-agentd-cli` is no longer needed and is deprecated. It will be removed in a
   future version.
+- When an agent logs in and has no previously logged in queues, the login flow now automatically
+  logs the agent into all queues assigned to them, emitting the usual queue login bus events.
 
 ## 26.03 {#26-03}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change describing a new agent queue login behavior; no runtime code or configuration is modified.
> 
> **Overview**
> Adds an upgrade note for `26.05` stating that when an agent logs in with no previously logged-in queues, the system will now automatically log them into all assigned queues and emit the usual queue-login bus events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 387bb1bcf3ff01d79ab6adec59c5acb4619d3804. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->