### PR TITLE
upgrade_notes: add logging off from last queue of an agent behaviour change

### DIFF
--- a/website/uc-doc/upgrade/upgrade_notes.md
+++ b/website/uc-doc/upgrade/upgrade_notes.md
@@ -9,6 +9,7 @@ sidebar_position: 1
   future version.
 - When an agent logs in and has no previously logged in queues, the login flow now automatically
   logs the agent into all queues assigned to them, emitting the usual queue login bus events.
+- When an agent logs off from their last remaining logged in queue, the agent now logs off entirely.
 
 ## 26.03 {#26-03}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change adding an upgrade note about agent logoff behavior; no code or runtime behavior is modified.
> 
> **Overview**
> Updates `website/uc-doc/upgrade/upgrade_notes.md` for **26.05** to document a behavior change: when an agent logs off their *last* remaining logged-in queue, they are now logged off entirely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db13819d6f5022562517f5d29931a0aafc57df2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->