### PR TITLE
sprint review 26.05

### DIFF
--- a/website/release-notes/sprint-review-2605.md
+++ b/website/release-notes/sprint-review-2605.md
@@ -14,7 +14,6 @@ Here is a short review of the Wazo Platform 26.05 release.
 
 ## Bug Fixes
 - **recording**: pausing/resuming a recording for a queue agent while in a call is now fixed.
-- **provisioning**: provisioning a phone using the provisioning code when the main (first) line of a user assigned the WebRTC endpoint to the phone. The API now hides the provisioning code in the user listing for that case
 - **trunks**: when deleting a tenant, associated trunks stayed registered on asterisk. This now has been fixed.
 - **upgrade**: wazo-confd was improved to avoid timeouts when upgrading a system with 2,000 users or more.
  

--- a/website/release-notes/sprint-review-2605.md
+++ b/website/release-notes/sprint-review-2605.md
@@ -1,0 +1,47 @@
+---
+title: Wazo Platform 26.05 Released
+date: 2026-05-01T15:10:00
+authors: wazoplatform
+category: Wazo Platform
+tags: [wazo-platform, development]
+slug: release-review-2605
+status: published
+---
+
+Hello Wazo Platform community!
+
+Here is a short review of the Wazo Platform 26.05 release.
+
+## Bug Fixes
+- **recording**: pausing/resuming a recording for an agent while in a call is now fixed.
+- **provisioning**: provisioning a phone using the provisioning code when the main (first) line of a user assigned the WebRTC endpoint to the phone. The API now hides the provisioning code in the user listing for that case
+- **trunks**: when deleting a tenant, associated trunks stayed registered on asterisk. This now has been fixed.
+- **upgrade**: wazo-confd was improved to avoid timeouts when upgrading a system with 2,000 users or more.
+ 
+## Technical
+- **auth**: mobile offline logins are now limited to one active refresh token per user; every new mobile offline login request revokes any existing refresh token and their sessions, even if client_id is reused (a fresh refresh token is always returned);
+- **agents**: login per queue was improved. The agent is now logged off when they decide to logoff the last queue associated with them. Likewise, when the agent logs in and there are no queues logged in, all their associated queues are logged in. wazo-agentd-cli was also updated to include per-queue status and login per queue functionality.
+- **caller ID**: the user outgoing caller ID API now exposes the caller ID name.
+- **call listening**: the call listening feature has been removed as it was not multi-tenant
+
+## Ongoing Features
+- **multi-channel communication**: multi-channel chat support framework
+
+See you at the next release review!
+
+## Resources
+
+- [Install Wazo Platform](/use-cases)
+- [Upgrade Wazo and Wazo Platform](/uc-doc/upgrade/). Be sure to read the
+  [breaking changes](/uc-doc/upgrade/upgrade_notes#26-05)
+
+<!-- truncate -->
+
+Sources:
+
+- [Upgrade notes](/uc-doc/upgrade/upgrade_notes#26-05)
+
+## Discussion
+
+Comments or questions in
+[this forum post](https://wazo-platform.discourse.group/t/blog-wazo-platform-26-05-released).

--- a/website/release-notes/sprint-review-2605.md
+++ b/website/release-notes/sprint-review-2605.md
@@ -13,7 +13,7 @@ Hello Wazo Platform community!
 Here is a short review of the Wazo Platform 26.05 release.
 
 ## Bug Fixes
-- **recording**: pausing/resuming a recording for an agent while in a call is now fixed.
+- **recording**: pausing/resuming a recording for a queue agent while in a call is now fixed.
 - **provisioning**: provisioning a phone using the provisioning code when the main (first) line of a user assigned the WebRTC endpoint to the phone. The API now hides the provisioning code in the user listing for that case
 - **trunks**: when deleting a tenant, associated trunks stayed registered on asterisk. This now has been fixed.
 - **upgrade**: wazo-confd was improved to avoid timeouts when upgrading a system with 2,000 users or more.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change adding a new release notes post; no runtime code paths are modified.
> 
> **Overview**
> Adds a new published release-note post `website/release-notes/sprint-review-2605.md` for **Wazo Platform 26.05**, summarizing bug fixes, technical changes (auth refresh-token revocation behavior, agent per-queue login updates, caller ID API exposure, and call listening removal), and linking to upgrade notes and discussion resources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a157a3573f9e07b4464f2dab20c951f5f5814309. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->