### PR TITLE
upgrade_notes: add entry for 26.06

### DIFF
--- a/website/uc-doc/upgrade/upgrade_notes.md
+++ b/website/uc-doc/upgrade/upgrade_notes.md
@@ -3,6 +3,10 @@ title: Upgrade notes
 sidebar_position: 1
 ---
 
+## 26.06 {#26-06}
+
+- Fixed a critical security issue in wazo-webhookd.
+
 ## 26.05 {#26-05}
 
 - The `-c` flag of `wazo-agentd-cli` is no longer needed and is deprecated. It will be removed in a


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime or behavior changes, just records a security fix in release notes.
> 
> **Overview**
> Adds a new `26.06` section to `website/uc-doc/upgrade/upgrade_notes.md` noting a *critical security issue fix* in `wazo-webhookd`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 226436ef04a34840eb96d5efbcf11d7027a7ab0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->