### PR TITLE
sprint review 26.06

### DIFF
--- a/website/release-notes/sprint-review-2606.md
+++ b/website/release-notes/sprint-review-2606.md
@@ -1,0 +1,44 @@
+---
+title: Wazo Platform 26.06 Released
+date: 2026-05-19T15:04:00
+authors: wazoplatform
+category: Wazo Platform
+tags: [wazo-platform, development]
+slug: release-review-2606
+status: published
+---
+
+Hello Wazo Platform community!
+
+Here is a short review of the Wazo Platform 26.06 release.
+
+## New Features in This Release
+- **Mobile PSTN Fallback**: mobile app call path in wazo-calld now supports a fallback to PSTN when mobile app does not register in time
+ 
+## Bug Fixes
+- **switchboards**: fix a phantom call scenario when a blind transfer is done to an IVR option that calls a switchboard
+- **diversion**: fix a missing SIP Diversion header when a group reaches a fallback or is forwarded
+- **devices**: fixed an issue where deleting a user reset a device to autoprov even though other users were assigned to another line of the same device
+- **webhooks**: fixed a security issue
+ 
+## Technical
+- **bus**: Switched consumer queues to exclusive to align with RabbitMQ's deprecation of transient non-exclusive queues and ensure forward compatibility.
+
+See you at the next release review!
+
+## Resources
+
+- [Install Wazo Platform](/use-cases)
+- [Upgrade Wazo and Wazo Platform](/uc-doc/upgrade/). Be sure to read the
+  [breaking changes](/uc-doc/upgrade/upgrade_notes#26-06)
+
+<!-- truncate -->
+
+Sources:
+
+- [Upgrade notes](/uc-doc/upgrade/upgrade_notes#26-06)
+
+## Discussion
+
+Comments or questions in
+[this forum post](https://wazo-platform.discourse.group/t/blog-wazo-platform-26-06-released).

--- a/website/release-notes/sprint-review-2606.md
+++ b/website/release-notes/sprint-review-2606.md
@@ -16,13 +16,13 @@ Here is a short review of the Wazo Platform 26.06 release.
 - **Mobile PSTN Fallback**: mobile app call path in wazo-calld now supports a fallback to PSTN when mobile app does not register in time
  
 ## Bug Fixes
-- **switchboards**: fix a phantom call scenario when a blind transfer is done to an IVR option that calls a switchboard
-- **diversion**: fix a missing SIP Diversion header when a group reaches a fallback or is forwarded
+- **switchboards**: fixed a phantom call scenario when a blind transfer is done to an IVR option that calls a switchboard
+- **diversion**: fixed a missing SIP Diversion header when a group reaches a fallback or is forwarded
 - **devices**: fixed an issue where deleting a user reset a device to autoprov even though other users were assigned to another line of the same device
 - **webhooks**: fixed a security issue
  
 ## Technical
-- **bus**: Switched consumer queues to exclusive to align with RabbitMQ's deprecation of transient non-exclusive queues and ensure forward compatibility.
+- **bus**: switched consumer queues to exclusive to align with RabbitMQ's deprecation of transient non-exclusive queues and ensure forward compatibility
 
 See you at the next release review!
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a new release-notes markdown page only; no runtime code paths are modified.
> 
> **Overview**
> Adds a new published release review page `website/release-notes/sprint-review-2606.md` for **Wazo Platform 26.06**, summarizing one new feature (mobile PSTN fallback), several bug fixes, and a technical change around RabbitMQ consumer queue exclusivity, plus upgrade/resources links and a discussion forum link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 666da25a180e001bd8c5d8f56aa50d0804f194d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->