### PR TITLE
Change solidjs link from main website to github repo website

### DIFF
--- a/website/blog/2022-11-hackathon-2022-group-chat.md
+++ b/website/blog/2022-11-hackathon-2022-group-chat.md
@@ -103,7 +103,7 @@ are more than one character. This is how variations for an emoji are handled ❤
 ![front view cottage (small)](../static/images/blog/hackathon-2022/group-chat/create-room.jpg)
 ![rear view cottage lake (small)](../static/images/blog/hackathon-2022/group-chat/emoji-picker.jpg)
 
-For the UI part, we used the [SolidJS](https://www.solidjs.com/) reactive library and our SDK
+For the UI part, we used the [SolidJS](https://github.com/solidjs/solid) reactive library and our SDK
 [wazo-js-sdk](https://github.com/wazo-platform/wazo-js-sdk). Building the UI was quite
 straightforward since our SDK handled token creation and allowed us to use the preconfigured
 WebSocket Client.


### PR DESCRIPTION
Main wedsite https://www.solidjs.com is blocked (HTTP 403) when tested by our pipeline from a AWS agent. Using a github link still give visibility on solidjs and is no longer blocked by our test pipeline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL change with no runtime or security impact.
> 
> **Overview**
> Updates the **SolidJS** link in the 2022 hackathon group-chat blog post from `https://www.solidjs.com` to `https://github.com/solidjs/solid` so automated checks (e.g. AWS pipeline agents) no longer hit HTTP 403 on the main site while readers still get a working reference to SolidJS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e120f0d12e82acaa1bce9c9e8fc8eeecf450e1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->