### PR TITLE
[ITEM-394] Surface voicemail redirections in CDR

### DIFF
--- a/website/uc-doc/upgrade/upgrade_notes.md
+++ b/website/uc-doc/upgrade/upgrade_notes.md
@@ -12,6 +12,11 @@ sidebar_position: 1
   thread count. Custom `max_threads` values are automatically renamed to `min_threads`, so tuned
   systems keep the same number of always-ready threads. See the
   [performance documentation](/uc-doc/system/performance) for details.
+- CDRs now indicate when an unanswered call was redirected to a voicemail: `call_status` is reported
+  as `voicemail` (instead of `unknown`), and `destination_details` carries a `voicemail` type with
+  the voicemail's `id` and `name`. The other `destination_*` fields are unchanged (they still
+  describe the dialed user). This applies to calls placed after the upgrade only; existing CDRs are
+  not backfilled.
 
 ## 26.07 {#26-07}
 


### PR DESCRIPTION
Document that CDRs now report call_status "voicemail" and a voicemail
destination_details entry when an unanswered call is redirected to a voicemail.

ITEM-394

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to upgrade notes; no runtime or API code in this PR.
> 
> **Overview**
> Adds a **26.08** upgrade note describing how CDRs represent unanswered calls that end in voicemail after the platform change.
> 
> For new calls after upgrade, **`call_status`** becomes **`voicemail`** instead of **`unknown`**, and **`destination_details`** includes a **`voicemail`** entry with **`id`** and **`name`**. Other **`destination_*`** fields still describe the dialed user. Historical CDRs are not updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2e507b0f3805ffec82f2612d0e6f0e08ed3f964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->