### PR TITLE
add upgrade notes template for 26.07

### DIFF
--- a/website/uc-doc/upgrade/upgrade_notes.md
+++ b/website/uc-doc/upgrade/upgrade_notes.md
@@ -3,6 +3,8 @@ title: Upgrade notes
 sidebar_position: 1
 ---
 
+## 26.07 {#26-07}
+
 ## 26.06 {#26-06}
 
 - Fixed a critical security issue in wazo-webhookd.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only placeholder with no runtime or upgrade behavior changes.
> 
> **Overview**
> Adds a **26.07** heading (`## 26.07 {#26-07}`) at the top of `upgrade_notes.md`, above **26.06**, as a placeholder for the next release’s upgrade notes. No bullet points or content yet—same anchor pattern as other version sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 945dd9dfb890a5af72460319c19ed66bfceff98f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->