### PR TITLE
Add 26.07 upgrade note for wazo-chatd identity endpoints

### DIFF
--- a/website/uc-doc/upgrade/upgrade_notes.md
+++ b/website/uc-doc/upgrade/upgrade_notes.md
@@ -5,6 +5,10 @@ sidebar_position: 1
 
 ## 26.07 {#26-07}
 
+- The `wazo-chatd` per-user identity endpoints (`/users/{user_uuid}/identities`) have been removed
+  and replaced with a tenant-scoped `/identities` set. The `/users/me/identities` endpoint is
+  unaffected.
+
 ## 26.06 {#26-06}
 
 - Fixed a critical security issue in wazo-webhookd.


### PR DESCRIPTION
## Summary

Adds a 26.07 upgrade note documenting the removal of the `wazo-chatd` per-user identity endpoints (`/users/{user_uuid}/identities`), now replaced by a tenant-scoped `/identities` set. The `/users/me/identities` endpoint is unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration impact.
> 
> **Overview**
> Adds a **26.07** entry to the upgrade notes describing a **wazo-chatd** API change for integrators upgrading to that release.
> 
> Per-user identity routes at `/users/{user_uuid}/identities` are **removed**; callers should use the tenant-scoped **`/identities`** API instead. **`/users/me/identities`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9abf73c533922ade4027bf3bc33c8884944eb171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->