### PR TITLE
add sprint review 26.07 blog post

### DIFF
--- a/website/release-notes/sprint-review-2607.md
+++ b/website/release-notes/sprint-review-2607.md
@@ -1,0 +1,43 @@
+---
+title: Wazo Platform 26.07 Released
+date: 2026-06-26T09:00:00
+authors: wazoplatform
+category: Wazo Platform
+tags: [wazo-platform, development]
+slug: release-review-2607
+status: published
+---
+
+Hello Wazo Platform community!
+
+Here is a short review of the Wazo Platform 26.07 release.
+
+## Bug Fixes
+- **debug**: Verify sufficient free space before creating the tarball to avoid overfilling storage.
+- **dird**: Fixed an issue that could prevent the reverse lookup timeout from being configured.
+- **webhookd**: Fixed an issue that prevented token reuse between push notifications.
+ 
+## Technical
+- **asterisk**: upgraded to 22.10.0
+ 
+## Ongoing Features
+- **services**: various under-the-hood performance optimizations for larger deployments
+
+See you at the next release review!
+
+## Resources
+
+- [Install Wazo Platform](/use-cases)
+- [Upgrade Wazo and Wazo Platform](/uc-doc/upgrade/). Be sure to read the
+  [breaking changes](/uc-doc/upgrade/upgrade_notes#26-07)
+
+<!-- truncate -->
+
+Sources:
+
+- [Upgrade notes](/uc-doc/upgrade/upgrade_notes#26-07)
+
+## Discussion
+
+Comments or questions in
+[this forum post](https://wazo-platform.discourse.group/t/blog-wazo-platform-26-07-released).

--- a/website/release-notes/sprint-review-2607.md
+++ b/website/release-notes/sprint-review-2607.md
@@ -12,16 +12,29 @@ Hello Wazo Platform community!
 
 Here is a short review of the Wazo Platform 26.07 release.
 
+## New Features in this release
+- **chatd**: Added endpoints to manage connector identities. An admin can now set, update, or
+remove a user's connector identity
+- **stats**: Agent statistics now include per-queue metrics
+- **calld**: Set diversion header for queue calls
+
 ## Bug Fixes
-- **debug**: Verify sufficient free space before creating the tarball to avoid overfilling storage.
-- **dird**: Fixed an issue that could prevent the reverse lookup timeout from being configured.
-- **webhookd**: Fixed an issue that prevented token reuse between push notifications.
- 
+- **calls**: Carry over transferee identity for caller ID during blind transfers, in all directions
+- **chatd**: Fixed an issue with cross-tenant isolation when sending/receiving connector messages
+- **debug**: Verify sufficient free space before creating the tarball to avoid overfilling storage
+- **dird**: Fixed an issue that could prevent the reverse lookup timeout from being configured
+- **webhookd**: Fixed an issue that prevented token reuse between push notifications
+- **agid**: Allow spaces in non-quoted caller ID
+- **calld**: Fixed an issue that prevented recording announcements from playing for automatic call recordings
+
 ## Technical
-- **asterisk**: upgraded to 22.10.0
- 
+- **asterisk**: Upgraded to 22.10.0
+- **auth**: Modifying a user's email address no longer invalidates refresh tokens
+- **services**: Improved logging by adding request/response correlation and other improvements
+- **provisioning**: Ensure `deletable=false` for default device configurations
+
 ## Ongoing Features
-- **services**: various under-the-hood performance optimizations for larger deployments
+- **services**: Various under-the-hood performance optimizations for larger deployments
 
 See you at the next release review!
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only addition with no application or build logic changes.
> 
> **Overview**
> Adds a published **26.07** release review at `website/release-notes/sprint-review-2607.md`, matching the recent sprint-review format (front matter, truncate, upgrade notes link, Discourse discussion).
> 
> The post documents what shipped in **26.07**: connector-identity APIs in **chatd**, per-queue agent stats, queue-call diversion in **calld**; fixes across calls, chatd tenant isolation, debug tarball space checks, dird, webhookd, agid, and calld recordings; plus Asterisk **22.10.0**, auth email/refresh-token behavior, logging correlation, and default provisioning configs marked non-deletable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee0e45c73209977304c6b213b064c3328f3c927c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->