### PR TITLE
improve-typing-options

### DIFF
--- a/website/uc-doc/contributors/typing.md
+++ b/website/uc-doc/contributors/typing.md
@@ -562,7 +562,9 @@ warn_unused_ignores = true
 strict_equality = true
 extra_checks = true
 no_warn_no_return = true
+scripts_are_modules = true  # default pre-commit behavior
 
+explicit_package_bases = true
 [[tool.mypy.overrides]]
 module = [
     "*.tests.*",


### PR DESCRIPTION
Why: document the mypy options needed so that pre-commit and CI
resolve module paths the same way in repositories with scripts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `typing.md`; no runtime or tooling behavior is modified in this PR.
> 
> **Overview**
> Updates the sample **`[tool.mypy]`** block in the contributors typing guide so repos with **scripts** can align module resolution between **pre-commit** and **CI**.
> 
> Adds **`scripts_are_modules = true`** (noted as default pre-commit behavior) and **`explicit_package_bases = true`** to the strict example config alongside the existing overrides for tests and integration suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de12c713fe7bc8da0c17a025c214b04ae1299905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->