### PR TITLE
ITEM-447-dynamic-thread-pool

### DIFF
--- a/website/uc-doc/system/performance.md
+++ b/website/uc-doc/system/performance.md
@@ -7,38 +7,29 @@ may require some modifications to improve the performance or quality of calls.
 
 ## Increase the number of concurrent requests
 
-Wazo services can handle multiple requests concurrently. The setting `max_threads` will define the
-number of threads and database connections that Wazo daemons will keep ready for processing
-requests.
+Wazo services can handle multiple requests concurrently. Two settings control the pool of worker
+threads processing requests: `min_threads` defines the number of threads and database connections
+that Wazo daemons keep ready at all times, and `max_threads` defines the ceiling the pool can grow
+to when the demand increases. Extra threads and database connections are released automatically when
+the demand decreases.
 
-Since this setting increases the number of database connections, you may also have to increase the
-maximum number of database connections. By default, Wazo uses a maximum of about 50 connections and
-PostgreSQL accepts a maximum of 100 connections.
+Database connections scale with the thread pool: a service holds `min_threads` connections
+permanently and may open up to `max_threads` connections during peaks. The sum of `max_threads` over
+all services should stay below the maximum number of database connections. Wazo configures
+PostgreSQL with `max_connections = 2048` by default, which leaves ample headroom.
 
 For example, to modify the number of concurrent requests:
 
-1. If needed, increase the number of maximum database connections by creating
-   `/etc/postgresql/15/main/conf.d/20-custom-max-connections.conf`:
-
-```ini
-max_connections = 200
-```
-
-2. Then restart the database and all services to apply the change:
-
-```shell
-wazo-service restart all
-```
-
-3. Increase the number of concurrent requests for `wazo-chatd` (for example) by creating a new file
+1. Increase the number of concurrent requests for `wazo-chatd` (for example) by creating a new file
    `/etc/wazo-chatd/conf.d/50-threads.yml`:
 
 ```yaml
 rest_api:
-  max_threads: 25
+  min_threads: 10
+  max_threads: 200
 ```
 
-4. Then restart the service to apply the change:
+2. Then restart the service to apply the change:
 
 ```shell
 systemctl restart wazo-chatd

--- a/website/uc-doc/upgrade/upgrade_notes.md
+++ b/website/uc-doc/upgrade/upgrade_notes.md
@@ -7,6 +7,11 @@ sidebar_position: 1
 
 - The `-c` flag of `wazo-plugind-cli` is no longer needed and is deprecated. It will be removed in a
   future version.
+- REST API worker threads of Wazo services now scale with demand: new `rest_api.min_threads` setting
+  (threads kept ready at all times), and `rest_api.max_threads` is now a ceiling instead of a fixed
+  thread count. Custom `max_threads` values are automatically renamed to `min_threads`, so tuned
+  systems keep the same number of always-ready threads. See the
+  [performance documentation](/uc-doc/system/performance) for details.
 
 ## 26.07 {#26-07}
 


### PR DESCRIPTION
Why: max_threads changes meaning from fixed thread count to ceiling,
and min_threads is introduced; the performance page also claimed
PostgreSQL accepts 100 connections while wazo-dbms ships 2048.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration behavior in this diff.
> 
> **Overview**
> **Docs align with the dynamic REST API worker thread pool** introduced in 26.08: `rest_api.min_threads` (always-ready workers) and `rest_api.max_threads` as a demand-driven ceiling, with automatic migration of custom `max_threads` to `min_threads` called out in **26.08 upgrade notes** and linked to the performance page.
> 
> The **performance** guide now explains min/max thread behavior and DB connection scaling, drops the old PostgreSQL `max_connections` tuning workflow, and states the default **`max_connections = 2048`** (replacing the outdated ~50/100 figures). The `wazo-chatd` example shows both `min_threads` and `max_threads`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1702861aa064efb6b7385a3d4c96ec6e7c6d6504. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->