### PR TITLE
Document scaling wazo-auth, fix the nginx entry points

### DIFF
--- a/website/uc-doc/system/nginx.md
+++ b/website/uc-doc/system/nginx.md
@@ -4,29 +4,32 @@ title: Nginx
 
 Wazo use nginx as a web server and reverse proxy.
 
-In its default configuration, the nginx server listens on port TCP/80 and TCP/443 and allows these
-services to be used:
+It listens on two entry points:
 
-- The agent management server (wazo-agentd)
-- The authentication server (wazo-auth)
-- The configuration server (wazo-confd)
-- The telephony service interface (wazo-calld)
-- The directory service (wazo-dird)
-- The AMI HTTP interface (wazo-amid)
-- The websocket interface (wazo-websocketd)
-- Asterisk WebSocket (xivo-config)
+- TCP/443, for the clients of the public API. Plain HTTP on TCP/80 is redirected to it. The services
+  reachable this way are the ones enabled in `/etc/nginx/locations/https-enabled`:
 
-An administrator can easily modify the configuration to allow or disallow some services.
+  - The agent management server (wazo-agentd)
+  - The authentication server (wazo-auth)
+  - The configuration server (wazo-confd)
+  - The telephony service interface (wazo-calld)
+  - The directory service (wazo-dird)
+  - The AMI HTTP interface (wazo-amid)
+  - The websocket interface (wazo-websocketd)
+  - Asterisk WebSocket (xivo-config)
 
-To do so, an administrator only has to create a symbolic link inside the
-`/etc/nginx/locations/http-enabled` directory to the corresponding file in the
-`/etc/nginx/locations/http-available` directory, and then reload nginx with
-`systemctl reload nginx`. A similar operation must be done for HTTPS.
+- `127.0.0.1:80`, for the requests the Wazo services send to each other, from the locations enabled
+  in `/etc/nginx/locations/http-enabled`. This entry point is bound to the loopback interface and is
+  not reachable from outside the machine. Its requests are logged in
+  `/var/log/nginx/wazo-internal.access.log`.
+
+An administrator can allow or disallow a service on the public API by creating or removing a
+symbolic link inside `/etc/nginx/locations/https-enabled`, pointing to the corresponding file in
+`/etc/nginx/locations/https-available`, then reloading nginx.
 
 For example, to enable all the available services:
 
 ```shell
-ln -sf /etc/nginx/locations/http-available/* /etc/nginx/locations/http-enabled
 ln -sf /etc/nginx/locations/https-available/* /etc/nginx/locations/https-enabled
 systemctl reload nginx
 ```
@@ -34,9 +37,12 @@ systemctl reload nginx
 To disable all the services other than the web interface:
 
 ```shell
-rm /etc/nginx/locations/http-enabled/* /etc/nginx/locations/https-enabled/*
+rm /etc/nginx/locations/https-enabled/*
 systemctl reload nginx
 ```
+
+The `http-available` and `http-enabled` directories work the same way, but for the internal entry
+point: removing a location there prevents the other Wazo services from reaching that service.
 
 Rate limiting is defined in `/etc/nginx/sites-available/wazo`. It is applied to unauthenticated
 resources only at the moment.

--- a/website/uc-doc/system/performance.md
+++ b/website/uc-doc/system/performance.md
@@ -34,3 +34,41 @@ rest_api:
 ```shell
 systemctl restart wazo-chatd
 ```
+
+## Scale wazo-auth to several processes
+
+The thread pool above scales a service inside one process, which Python limits to roughly one CPU
+core. Beyond that, wazo-auth can run as several processes. Its work is split into three roles,
+selected with the repeatable `--role` option or the `roles` configuration key:
+
+- `api`: serve the REST API
+- `scheduler`: run the periodic tasks (expired token and session cleanup)
+- `init`: run the one-shot startup tasks (schema upgrade, policy update, bootstrap user)
+
+One process runs all three by default, so an existing installation is unchanged. Instances
+coordinate through PostgreSQL advisory locks (startup tasks serialized, a single scheduler leader
+elected), so running several is safe.
+
+Add API-only processes with the systemd template, the instance name being the port to listen on:
+
+```shell
+systemctl enable --now wazo-auth-worker@19497
+```
+
+Workers stop and start with `wazo-auth.service`. Send traffic to them by adding one line per worker
+in `/etc/nginx/conf.d/wazo-auth-upstream.conf`:
+
+```nginx
+upstream wazo-auth {
+    server 127.0.0.1:9497;
+    server 127.0.0.1:19497;
+}
+```
+
+```shell
+nginx -t && systemctl reload nginx
+```
+
+Public and internal requests both use this upstream, so both are load balanced. Each instance logs
+to journald (`journalctl -t wazo-auth-worker@19497`), and the nginx access logs report which backend
+served a request in `$upstream_addr`.

--- a/website/uc-doc/upgrade/upgrade_notes.md
+++ b/website/uc-doc/upgrade/upgrade_notes.md
@@ -3,6 +3,16 @@ title: Upgrade notes
 sidebar_position: 1
 ---
 
+## 26.09 {#26-09}
+
+- The `--http-worker` flag of `wazo-auth` (26.08) and the `rest_api.reuse_port` setting it required
+  have been removed; if set in `/etc/wazo-auth/conf.d/`, the latter is now ignored. Extra processes
+  are started with the `wazo-auth-worker@<port>` systemd units and declared in the nginx upstream,
+  as described in the [performance documentation](/uc-doc/system/performance).
+- Wazo services now reach `wazo-auth` through nginx (`http://localhost/api/auth`) instead of
+  `localhost:9497`. Internal requests are logged in `/var/log/nginx/wazo-internal.access.log`, and
+  nginx being on that path, the services can no longer authenticate each other while it is stopped.
+
 ## 26.08 {#26-08}
 
 - The `-c` flag of `wazo-plugind-cli` is no longer needed and is deprecated. It will be removed in a


### PR DESCRIPTION
Documents how to run wazo-auth as several processes, and fixes the nginx page,
which described `http-enabled` as the plain-HTTP toggle for public services.

Two commits:

* **performance.md** — a section after the thread-pool one it builds on: the
  three roles (`api`, `scheduler`, `init`), the fact that the default single
  process is unchanged and that several instances are safe (they coordinate
  through PostgreSQL advisory locks), the `wazo-auth-worker@<port>` units, the
  nginx upstream, and where per-instance output goes.
* **nginx.md** — the page told administrators to
  `ln -sf /etc/nginx/locations/http-available/* http-enabled`, which now enables
  internal locations on the loopback entry point. It describes the two entry
  points instead: public API on `:443` (`https-enabled`) and internal requests
  on `127.0.0.1:80` (`http-enabled`).

The upgrade note covers the removal of `--http-worker` and `rest_api.reuse_port`
(wazo-platform/wazo-auth#449, merged), plus internal requests now going through
nginx (wazo-platform/wazo-nginx#23).

Ticket: TASK-504

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, security, or configuration code impact.
> 
> **Overview**
> Documents how to **scale `wazo-auth` across multiple processes** and corrects the nginx admin docs for the current public vs internal entry points.
> 
> Adds a performance section covering the `api` / `scheduler` / `init` roles, safe multi-instance coordination via PostgreSQL locks, `wazo-auth-worker@<port>` units, and nginx upstream load balancing.
> 
> Rewrites the nginx page so `https-enabled` controls the public API on `:443`, while `http-enabled` is only the loopback internal entry point—not a plain-HTTP toggle for public services.
> 
> Adds **26.09** upgrade notes for the removal of `--http-worker` / `rest_api.reuse_port` and for internal auth traffic now going through nginx.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a3b31d414821e32371394eec806198e33c5262a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->