### PR TITLE
fix(website): use template literal in mermaid sidecar error

### DIFF
--- a/website/src/plugins/documentation/builder/index.ts
+++ b/website/src/plugins/documentation/builder/index.ts
@@ -53,8 +53,7 @@ const inlineMermaidDiagrams = (content: string, dir: string) =>
         // image reference in place would ship a guaranteed 404 that nothing
         // else on this site catches -- fail loudly instead
         throw new Error(
-          `Missing mermaid sidecar for "${imageRef}" in ${dir}: expected ${diagram}. ` +
-            'Add the mermaid source next to the .puml (see README.md, "Content Change").',
+          `Missing mermaid sidecar for "${imageRef}" in ${dir}: expected ${diagram}. Add the mermaid source next to the .puml (see README.md, "Content Change").`,
         );
       }
       return `\`\`\`mermaid\n${fs.readFileSync(diagram, 'utf8').trim()}\n\`\`\``;


### PR DESCRIPTION
## Summary of the changes

- `biome` `lint/style/useTemplate` error on master, introduced in #908: the mermaid sidecar error message used string concatenation. Turned it into a single template literal.

This is what turned *Test deployment* red on #908. It merged anyway because master only requires `local/wazo-check` — the GitHub Actions checks aren't in the required list.

## How to test

- `cd website && yarn lint` — passes (was `Found 1 error.`)
- `yarn build` — succeeds
- Temporarily `mv content/amid/diagram.mmd /tmp/` and rebuild: still fails with `Missing mermaid sidecar for "![amid schema](diagram.svg)" …`