### PR TITLE
Fix the two links reported as 404 by the scrap tests

### DIFF
--- a/website/redirects.ts
+++ b/website/redirects.ts
@@ -8,6 +8,10 @@ const REDIRECTS: Options['redirects'] = [
     to: '/uc-doc/administration/contact_directories',
   },
   {
+    from: '/uc-doc/administration/call-policy',
+    to: '/uc-doc/administration/call_policy',
+  },
+  {
     from: '/uc-doc/administration/interconnections/introduction',
     to: '/uc-doc/administration/interconnections',
   },

--- a/website/release-notes/sprint-review-2001.md
+++ b/website/release-notes/sprint-review-2001.md
@@ -17,7 +17,7 @@ Here is a short review of the Wazo Platform 20.01 release.
 - **Switchboard**: We have worked on improving the switchboard reactivity. In this version, the time to answer a call has been reduced by half. These changes may also impact positively the response time of other actions made on the calls in a switchboard.
 - **Monitoring**: We have added a new HTTP resource to retrieve the current status of user telephony lines in wazo-calld REST API. This allows an external application to know which phones are busy, available or disconnected. This feature is currently very similar to the wazo-chatd presence features, but it will be improved with more details irrelevant to wazo-chatd, like the round-trip time to a phone.
 - **Users**: We have improved the users REST API to add information related to user interception. When getting a user's details, you may now get the list of people that this user is allowed to intercept.
-- **Class 4**: We are releasing a first version of the SBC and call routing features of Wazo Platform, featuring Kamailio. Here are the links to the [installation documentation](https://wazo-platform.org/use-cases/class-4) and [REST API documentation](/documentation/overview/router-confd).
+- **Class 4**: We are releasing a first version of the SBC and call routing features of Wazo Platform, featuring Kamailio. Here are the links to the [installation documentation](https://wazo-platform.org/use-cases/class-4) and [REST API documentation](https://github.com/wazo-platform/wazo-router-confd).
 
 ## Contributions
 

--- a/website/uc-doc/administration/call_policy.md
+++ b/website/uc-doc/administration/call_policy.md
@@ -1,6 +1,5 @@
 ---
 title: Call Policy
-slug: call-policy
 ---
 
 There exists multiple ways to constrain calls performed through the Wazo platform.

--- a/website/uc-doc/administration/index.md
+++ b/website/uc-doc/administration/index.md
@@ -11,7 +11,7 @@ All configurations are done via the [`wazo-confd` REST API](/documentation/api/c
     { text: 'Boss Secretary Filter', href: '/uc-doc/administration/boss_secretary_filter' },
     { text: 'Blocklist', href: '/uc-doc/administration/blocklist' },
     { text: 'Call Permissions', href: '/uc-doc/administration/call_permissions' },
-    { text: 'Call Policy', href: '/uc-doc/administration/call-policy' },
+    { text: 'Call Policy', href: '/uc-doc/administration/call_policy' },
     { text: 'Call Recording', href: '/uc-doc/administration/call_recording' },
     { text: 'Call Logs CallerID', href: '/uc-doc/administration/call_logs' },
     { text: 'Caller ID', href: '/uc-doc/administration/callerid' },


### PR DESCRIPTION
## Summary of the changes

- `/uc-doc/administration/call-policy` → `/uc-doc/administration/call_policy`: dropped the Docusaurus-only `slug: call-policy`, since the Gatsby build derives the page path from the file name and never emitted that URL. Added a redirect so the Docusaurus URL keeps working.
- `/documentation/overview/router-confd` → the `wazo-router-confd` GitHub repo: Gatsby emits that overview page as `router-confd.html` and Docusaurus redirects it to `/documentation` (C4 is archived), so no single path worked on both sites.

## How to test

- Run the scrap tests (`make test`) and confirm neither URL shows up under `###### PROBLEMS`.
- Go to `/uc-doc/administration` and click **Call Policy** — the page loads.
- Go to `/blog/sprint-review-2001` and click **REST API documentation** — it opens the repo.