### PR TITLE
docs: add development mirror page

### DIFF
--- a/website/uc-doc/administration/cli_tools/index.md
+++ b/website/uc-doc/administration/cli_tools/index.md
@@ -24,6 +24,9 @@ wazo-dist is the wazo repository sources manager. It is used to switch between d
 - switch to release candidate repository : `wazo-dist -m wazo-rc-bookworm`
 - switch to an archived version's repository: `wazo-dist -a wazo-25.14`
 
+See the [development mirror](/uc-doc/contributors/dev_mirror) documentation for the differences
+between these distributions.
+
 ### wazo-dist-upgrade
 
 `wazo-dist-upgrade` is used to upgrade Wazo when a major Debian upgrade is required, e.g. upgrading

--- a/website/uc-doc/contributors/dev_mirror.md
+++ b/website/uc-doc/contributors/dev_mirror.md
@@ -1,0 +1,106 @@
+---
+title: Development Mirror
+---
+
+The development mirror is the Debian repository where packages built from the `master` branches of
+the Wazo Platform repositories are published. It lets you run and test the code that will become the
+next release, before that release exists.
+
+:::warning
+
+The development mirror is for test and development environments only. Never point a production
+system at it: builds are published continuously, they are not a coordinated release, and there is no
+supported way back to the production mirror (see
+[Going back to production](#going-back-to-production)).
+
+:::
+
+## Distributions {#distributions}
+
+All Wazo distributions are served from `https://mirror.wazo.community/debian/`, one APT suite per
+channel. The suite name ends with the Debian release it is built for, so it must match the Debian
+version running on your machine (`bookworm` for Debian 12).
+
+| Suite               | Channel             | Contents                                              |
+| ------------------- | ------------------- | ----------------------------------------------------- |
+| `wazo-dev-bookworm` | Development         | Every build from `master`, published as merges happen |
+| `wazo-rc-bookworm`  | Release candidate   | Builds under validation for the upcoming release      |
+| `pelican-bookworm`  | Production (stable) | The current released version                          |
+
+Older Debian releases have their own suites (`wazo-dev-bullseye`, `pelican-bullseye`, and so on),
+and past releases are frozen under `https://mirror.wazo.community/archive/` as `wazo-<version>`
+suites.
+
+Only the `amd64` architecture is published.
+
+The version currently on each channel is exposed as a plain text file:
+
+```shell
+curl https://mirror.wazo.community/version/unstable   # development, e.g. 26.09
+curl https://mirror.wazo.community/version/stable     # production, e.g. 26.08
+curl https://mirror.wazo.community/version/oldstable  # previous production, e.g. 26.07
+```
+
+## Switching an existing installation {#switching-an-existing-installation}
+
+Use [wazo-dist](/uc-doc/administration/cli_tools#wazo-dist) to switch the sources, then upgrade:
+
+```shell
+wazo-dist -m wazo-dev-bookworm
+apt update
+wazo-upgrade
+```
+
+`wazo-dist` rewrites `/etc/apt/sources.list.d/wazo-dist.list` with a single `deb` line for the
+requested suite. `-m` selects the main repository (`/debian/`), `-a` selects the archive
+(`/archive/`). To check which mirror a machine is on:
+
+```shell
+cat /etc/apt/sources.list.d/wazo-dist.list
+```
+
+## Installing directly on the development version {#installing-directly-on-the-development-version}
+
+A fresh install from `wazo-ansible` uses the development mirror by default — that is what you get
+when you clone the repository and run the playbook without checking out a release tag. The
+[installation guide](/uc-doc/installation) describes the extra steps needed to install the stable
+version instead, so if you want a development platform, simply skip them.
+
+## Reading development version numbers {#reading-development-version-numbers}
+
+Packages on the development mirror carry a build-specific version instead of a plain release number:
+
+```
+26.09~20260813.160347.4086b2e4.deb12
+```
+
+- `26.09` — the release this build is heading towards
+- `20260813.160347` — the UTC date and time of the build
+- `4086b2e4` — the short Git commit the build was made from, so you can trace a package back to the
+  code it contains
+- `deb12` — the Debian release it was built for
+
+The `~` matters: in Debian version ordering, `26.09~<anything>` sorts _before_ the final `26.09`.
+Once 26.09 is released, a machine on the development mirror upgrades onto it cleanly rather than
+being stuck at a higher version.
+
+Because each package is built and published when its own repository is merged, the packages
+available at a given moment do not all come from the same point in time. A dev platform is a
+snapshot of many branches, not a release.
+
+## Going back to production {#going-back-to-production}
+
+Switching from the development mirror back to `pelican-bookworm` is **not** a supported operation.
+The installed packages are more recent than the ones on the production mirror, so APT will not
+replace them, and the database migrations already applied by `wazo-upgrade` are not reversible.
+
+Reinstall from scratch, or restore a snapshot taken before the switch. Taking a virtual machine
+snapshot before moving a platform to the development mirror is strongly recommended.
+
+## Troubleshooting {#troubleshooting}
+
+**`404 Not Found` on `apt update`** — the suite name probably does not match the Debian release
+installed on the machine. Check `cat /etc/os-release` and use the matching suite.
+
+**Invalid signature / `EXPKEYSIG`** — the mirror signing key is missing or expired on the machine.
+See the [upgrade troubleshooting section](/uc-doc/upgrade#troubleshooting).

--- a/website/uc-doc/contributors/index.md
+++ b/website/uc-doc/contributors/index.md
@@ -14,6 +14,7 @@ import CardList from '@site/src/components/Card/CardList';
     { text: 'Debug Asterisk', href: '/uc-doc/contributors/debug_asterisk' },
     { text: 'Debug Daemon', href: '/uc-doc/contributors/debug_daemon' },
     { text: 'Contributing to Wazo', href: '/uc-doc/contributors/contributing_to_wazo' },
+    { text: 'Development Mirror', href: '/uc-doc/contributors/dev_mirror' },
     { text: 'Generate Custom Prompts', href: '/uc-doc/contributors/generate_custom_prompts' },
     { text: 'Guidelines', href: '/uc-doc/contributors/guidelines' },
     { text: 'Network', href: '/uc-doc/contributors/network' },


### PR DESCRIPTION
## Summary of the changes

- New `/uc-doc/contributors/dev_mirror` page: the `wazo-dev` / `wazo-rc` / `pelican` suites, how to read a dev version string (`26.09~20260813.160347.4086b2e4.deb12`), switching with `wazo-dist`, and why there is no way back to production.
- Linked it from the contributors index and the `wazo-dist` section of the CLI tools page.

Two claims are judgement calls worth a reviewer's eye: that switching from dev back to `pelican` is unsupported (APT won't downgrade + migrations aren't reversible), and that packages land on dev independently per merge so a dev platform isn't a coordinated release.

## How to test

- Go to `/uc-doc/contributors/dev_mirror` and check the content.
- Check the new card on `/uc-doc/contributors` and the link under `wazo-dist` on `/uc-doc/administration/cli_tools`.